### PR TITLE
Merge transaction sender and cosigner

### DIFF
--- a/docs/source/library/network/payloads/transaction.rst
+++ b/docs/source/library/network/payloads/transaction.rst
@@ -4,13 +4,13 @@
 .. classoverview::
    :class:`neo3.network.payloads.transaction.Transaction`
    :class:`neo3.network.payloads.transaction.TransactionAttribute`
-   :class:`neo3.network.payloads.transaction.TransactionAttributeUsage`
+   :class:`neo3.network.payloads.transaction.TransactionAttributeType`
 
 This module contains the famous Transaction class.
 
 At its core is a byte array holding the instructions to be executed by the NEO virtual machine. Such instructions can include token balance updates or general smart contract execution.
 
-Auxiliary attributes are included for validation purposes and validity contraints (think; only valid until a certain block) among other reasons.
+Auxiliary attributes are included for validation purposes and validity constraints (think; only valid until a certain block) among other reasons.
 
 .. autoclass:: neo3.network.payloads.transaction.Transaction
    :undoc-members:
@@ -22,7 +22,7 @@ Auxiliary attributes are included for validation purposes and validity contraint
    :show-inheritance:
    :inherited-members:
 
-.. autoclass:: neo3.network.payloads.transaction.TransactionAttributeUsage
+.. autoclass:: neo3.network.payloads.transaction.TransactionAttributeType
    :undoc-members:
    :show-inheritance:
    :inherited-members:

--- a/docs/source/library/network/payloads/verification.rst
+++ b/docs/source/library/network/payloads/verification.rst
@@ -2,7 +2,7 @@
 =========================================================================
 
 .. classoverview::
-   :class:`~neo3.network.payloads.verification.Cosigner`
+   :class:`~neo3.network.payloads.verification.Signer`
    :class:`~neo3.network.payloads.verification.Witness`
    :class:`~neo3.network.payloads.verification.WitnessScope`
 
@@ -10,15 +10,15 @@ This module describes two validation forms found in the NEO chain.
 
 First we have validation of three verifiable objects, namely: :class:`~neo3.network.payloads.block.Block`, :class:`~neo3.network.payloads.consensus.ConsensusPayload` and :class:`~neo3.network.payloads.transaction.Transaction`. These are digitally signed using ECDSA. Validation of these objects is done using a so called witness. 
 
-A :class:`~neo3.network.payloads.verification.Witness` is a verification script executed by the virtual machine to validate the verifiable object. Validation failure prevents for example that a transaction is included in a block and broadcasted to the network. Taking the transaction example further, the witness carries a set of virtual machine opcodes (in its :attr:`~neo3.network.payloads.verification.Witness.invocation_script`) that load the transaction signatures into the internal data structures of the VM. Next, the :attr:`~neo3.network.payloads.verification.Witness.verification_script`, which are also virtual machine opcodes, performs the actual verification and operates on the data perviously setup by the invocation script. 
+A :class:`~neo3.network.payloads.verification.Witness` is a verification script executed by the virtual machine to validate the verifiable object. Validation failure prevents for example that a transaction is included in a block and broad casted to the network. Taking the transaction example further, the witness carries a set of virtual machine opcodes (in its :attr:`~neo3.network.payloads.verification.Witness.invocation_script`) that load the transaction signatures into the internal data structures of the VM. Next, the :attr:`~neo3.network.payloads.verification.Witness.verification_script`, which are also virtual machine opcodes, performs the actual verification and operates on the data previously setup by the invocation script.
 
 A second form of validation can be performed inside a smart contract using the `CheckWitness() <https://docs.neo.org/tutorial/en-us/9-smartContract/cgas/6_signature_and_verification.html#checkwitness-and-additional-witness>`__ system call. This can be used to limit certain smart contract functions to a specific user, other smart contract or group.
 
-To give this fine grained control NEO created so called cosigners and a set of verification scopes. Cosigners are attached to a transaction in its aptly named :attr:`~neo3.network.payloads.transaction.Transaction.cosigners` attribute and are matched according to the rules set by the verification scope. The various verification scopes can be configured using a :class:`~neo3.network.payloads.verification.WitnessScope` and are set in the :attr:`~neo3.network.payloads.verification.Cosigner.scope` attribute of a cosigner. 
+To give this fine grained control NEO created so called `signers` and a set of verification scopes. Signers are attached to a transaction in its aptly named :attr:`~neo3.network.payloads.transaction.Transaction.signers` attribute and are matched according to the rules set by the verification scope. The various verification scopes can be configured using a :class:`~neo3.network.payloads.verification.WitnessScope` and are set in the :attr:`~neo3.network.payloads.verification.Signer.scope` attribute of a signer.
 
 .. Note::
    
-   While multiple cosigner's can be attached to a transaction and thus multiple scopes can be set, only the first cosigner is looked at to determine the scope to use for :func:`CheckWitness()`.
+   While multiple signer's can be attached to a transaction and thus multiple scopes can be set, only the first signer is looked at to determine the scope to use for :func:`CheckWitness()`.
 
 .. autoclass:: neo3.network.payloads.verification.Witness
    :members:
@@ -32,7 +32,7 @@ To give this fine grained control NEO created so called cosigners and a set of v
    :show-inheritance:
    :inherited-members:
 
-.. autoclass:: neo3.network.payloads.verification.Cosigner
+.. autoclass:: neo3.network.payloads.verification.Signer
    :members:
    :undoc-members:
    :show-inheritance:

--- a/neo3/network/payloads/__init__.py
+++ b/neo3/network/payloads/__init__.py
@@ -3,9 +3,9 @@ from .inventory import InventoryPayload, InventoryType, IInventory
 from .version import VersionPayload
 from .address import NetworkAddress, AddrPayload, AddressState, DisconnectReason
 from .ping import PingPayload
-from .verification import Witness, WitnessScope, Cosigner
+from .verification import Witness, WitnessScope, Signer
 from .consensus import ConsensusData, ConsensusPayload
-from .transaction import Transaction, TransactionAttributeUsage, TransactionAttribute
+from .transaction import Transaction, TransactionAttribute, TransactionAttributeType
 from .block import Header, Block, MerkleBlockPayload, HeadersPayload, TrimmedBlock, GetBlocksPayload, \
     GetBlockByIndexPayload
 from .filter import FilterAddPayload, FilterLoadPayload
@@ -14,5 +14,5 @@ from .filter import FilterAddPayload, FilterLoadPayload
 __all__ = ['EmptyPayload', 'InventoryPayload', 'InventoryType', 'VersionPayload', 'NetworkAddress',
            'AddrPayload', 'PingPayload', 'Witness', 'WitnessScope', 'Header', 'Block', 'MerkleBlockPayload',
            'HeadersPayload', 'ConsensusData', 'ConsensusPayload', 'Transaction', 'TransactionAttribute',
-           'TransactionAttributeUsage', 'Cosigner', 'GetBlocksPayload', 'GetBlockByIndexPayload', 'FilterAddPayload',
+           'TransactionAttributeType', 'Signer', 'GetBlocksPayload', 'GetBlockByIndexPayload', 'FilterAddPayload',
            'FilterLoadPayload', 'TrimmedBlock']

--- a/neo3/network/payloads/consensus.py
+++ b/neo3/network/payloads/consensus.py
@@ -169,5 +169,5 @@ class ConsensusData(serialization.ISerializable):
         Args:
             reader: instance.
         """
-        self.primary_index = reader.read_var_int(max=1024)  # comes from C#'s Clockchain.MaxValidators
+        self.primary_index = reader.read_var_int(max=1024)  # comes from C#'s Blockchain.MaxValidators
         self.nonce = reader.read_uint64()

--- a/neo3/network/payloads/transaction.py
+++ b/neo3/network/payloads/transaction.py
@@ -1,26 +1,35 @@
+from __future__ import annotations
 import hashlib
+import abc
+from enum import Enum
 from typing import List
-from enum import IntEnum
 from neo3.core import Size as s, serialization, utils, types
 from neo3.network import payloads
 from neo3.vm import VMState
 from neo3 import settings
 
 
-class TransactionAttributeUsage(IntEnum):
-    URL = 0x81
+class TransactionAttributeType(Enum):
+    pass
 
 
 class TransactionAttribute(serialization.ISerializable):
     """
     Attributes that can be attached to a Transaction.
     """
-    def __init__(self, usage: TransactionAttributeUsage = None, data: bytes = None):
-        self.usage = usage
-        self.data = data if data else bytearray()
+    def __init__(self):
+        self.type_ = None
+        self.allow_multiple = False
 
     def __len__(self):
-        return s.uint8 + utils.get_var_size(self.data)
+        return s.uint8
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+        if type(self) != type(other):
+            return False
+        return True
 
     def serialize(self, writer: serialization.BinaryWriter) -> None:
         """
@@ -29,8 +38,12 @@ class TransactionAttribute(serialization.ISerializable):
         Args:
             writer: instance.
         """
-        writer.write_uint8(self.usage)
-        writer.write_var_bytes(self.data)
+        writer.write_uint8(self.type_)
+        self._serialize_without_type(writer)
+
+    @abc.abstractmethod
+    def _serialize_without_type(self, writer: serialization.BinaryWriter) -> None:
+        """ Serialize the remaining attributes"""
 
     def deserialize(self, reader: serialization.BinaryReader) -> None:
         """
@@ -39,8 +52,27 @@ class TransactionAttribute(serialization.ISerializable):
         Args:
             reader: instance.
         """
-        self.usage = TransactionAttributeUsage(reader.read_uint8())
-        self.data = reader.read_var_bytes(max=252)
+        if reader.read_uint8() != self.type_:
+            raise ValueError("Deserialization error - transaction attribute type mismatch")
+        self._deserialize_without_type(reader)
+
+    @staticmethod
+    def deserialize_from(reader: serialization.BinaryReader) -> TransactionAttribute:
+        """
+        Deserialize from a binary stream into a new TransactionAttribute
+        """
+        attribute_type = reader.read_uint8()
+        for sub in TransactionAttribute.__subclasses__():
+            child = sub()  # type: ignore
+            if child.type_ == attribute_type:
+                child._deserialize_without_type(reader)
+                return child
+        else:
+            raise ValueError("Deserialization error - unknown transaction attribute type")
+
+    @abc.abstractmethod
+    def _deserialize_without_type(self, reader: serialization.BinaryReader) -> None:
+        """ Deserialize the remaining attributes """
 
 
 class Transaction(serialization.ISerializable, payloads.IInventory):
@@ -53,31 +85,29 @@ class Transaction(serialization.ISerializable, payloads.IInventory):
     MAX_VALID_UNTIL_BLOCK_INCREMENT = 2102400
     #: the maximum number of transaction attributes for a single transaction
     MAX_TRANSACTION_ATTRIBUTES = 16
-    #: the maximum number of cosigners for a single
-    MAX_COSIGNERS = 16
 
     def __init__(self,
                  version: int = 0,
                  nonce: int = 0,
-                 sender: types.UInt160 = None,
                  system_fee: int = 0,
                  network_fee: int = 0,
                  valid_until_block: int = 0,
                  attributes: List[TransactionAttribute] = None,
-                 cosigners: List[payloads.Cosigner] = None,
+                 signers: List[payloads.Signer] = None,
                  script: bytes = None,
                  witnesses: List[payloads.Witness] = None,
                  protocol_magic: int = None):
         self.version = version
         self.nonce = nonce
-        #: Script hash of the first signing authority
-        self.sender = sender if sender else types.UInt160.zero()
         self.system_fee = system_fee
         self.network_fee = network_fee
         self.valid_until_block = valid_until_block
         self.attributes = attributes if attributes else []
         #: A list of authorities used by the :func:`ChecKWitness` smart contract system call.
-        self.cosigners = cosigners if cosigners else []
+        self.signers = signers if signers else []
+        #: Script hash of the first signing authority
+        self._sender = self.signers[0].account if len(self.signers) > 0 else types.UInt160.zero()
+
         self.script = script if script else b''
         #: A list of signing authorities used to validate the transaction.
         self.witnesses = witnesses if witnesses else []
@@ -96,9 +126,9 @@ class Transaction(serialization.ISerializable, payloads.IInventory):
             self.protocol_magic = 0x4F454E
 
     def __len__(self):
-        return (s.uint8 + s.uint32 + s.uint160 + s.uint64 + s.uint64 + s.uint32
+        return (s.uint8 + s.uint32 + s.uint64 + s.uint64 + s.uint32
                 + utils.get_var_size(self.attributes)
-                + utils.get_var_size(self.cosigners)
+                + utils.get_var_size(self.signers)
                 + utils.get_var_size(self.script)
                 + utils.get_var_size(self.witnesses))
 
@@ -137,6 +167,12 @@ class Transaction(serialization.ISerializable, payloads.IInventory):
             return types.UInt256(data=data)
 
     @property
+    def sender(self) -> types.UInt160:
+        if len(self.signers) == 0:
+            raise ValueError("Invalid transaction - signers can't be empty")
+        return self._sender
+
+    @property
     def inventory_type(self) -> payloads.InventoryType:
         """
         Inventory type identifier.
@@ -156,12 +192,11 @@ class Transaction(serialization.ISerializable, payloads.IInventory):
     def serialize_unsigned(self, writer: serialization.BinaryWriter) -> None:
         writer.write_uint8(self.version)
         writer.write_uint32(self.nonce)
-        writer.write_serializable(self.sender)
         writer.write_int64(self.system_fee)
         writer.write_int64(self.network_fee)
         writer.write_uint32(self.valid_until_block)
+        writer.write_serializable_list(self.signers)
         writer.write_serializable_list(self.attributes)
-        writer.write_serializable_list(self.cosigners)
         writer.write_var_bytes(self.script)
 
     def serialize_special(self, writer: serialization.BinaryWriter) -> None:
@@ -184,7 +219,6 @@ class Transaction(serialization.ISerializable, payloads.IInventory):
         if self.version > 0:
             raise ValueError("Deserialization error - invalid version")
         self.nonce = reader.read_uint32()
-        self.sender = reader.read_serializable(types.UInt160)
         self.system_fee = reader.read_int64()
         if self.system_fee < 0:
             raise ValueError("Deserialization error - negative system fee")
@@ -195,8 +229,9 @@ class Transaction(serialization.ISerializable, payloads.IInventory):
         # if (self.system_fee + self.network_fee < self.system_fee):
         #     raise ValueError("Deserialization error - overflow")
         self.valid_until_block = reader.read_uint32()
-        self.attributes = reader.read_serializable_list(TransactionAttribute)
-        self.cosigners = reader.read_serializable_list(payloads.Cosigner)
+        self.signers = Transaction._deserialize_signers(reader, self.MAX_TRANSACTION_ATTRIBUTES)
+        self.attributes = Transaction._deserialize_attributes(reader,
+                                                              self.MAX_TRANSACTION_ATTRIBUTES - len(self.signers))
         self.script = reader.read_var_bytes(max=65535)
         if len(self.script) == 0:
             raise ValueError("Deserialization error - invalid script length 0")
@@ -220,15 +255,43 @@ class Transaction(serialization.ISerializable, payloads.IInventory):
     def from_replica(self, replica):
         self.version = replica.version
         self.nonce = replica.nonce
-        self.sender = replica.sender
         self.system_fee = replica.system_fee
         self.network_fee = replica.network_fee
         self.valid_until_block = replica.valid_until_block
         self.attributes = replica.attributes
-        self.cosigners = replica.cosigners
+        self.signers = replica.signers
         self.script = replica.script
         self.witnesses = replica.witnesses
         self.block_height = replica.block_height
         self.vm_state = replica.vm_state
 
     # TODO: implement Verify methods once we have Snapshot support
+
+    @staticmethod
+    def _deserialize_signers(reader: serialization.BinaryReader, max_count: int) -> List[payloads.Signer]:
+        count = reader.read_var_int(max_count)
+        if count == 0:
+            raise ValueError("Deserialization error - signers can't be empty")
+
+        values: List[payloads.Signer] = []
+        for i in range(0, count):
+            signer = reader.read_serializable(payloads.Signer)
+            if i > 0 and signer.scope == payloads.WitnessScope.FEE_ONLY:
+                raise ValueError("Deserialization error - only the first signer can be fee only")
+            if signer in values:
+                raise ValueError("Deserialization error - duplicate signer")
+            values.append(signer)
+
+        return values
+
+    @staticmethod
+    def _deserialize_attributes(reader: serialization.BinaryReader, max_count: int) -> List[TransactionAttribute]:
+        count = reader.read_var_int(max_count)
+        values: List[TransactionAttribute] = []
+
+        for _ in range(0, count):
+            attribute = TransactionAttribute.deserialize_from(reader)
+            if not attribute.allow_multiple and attribute in values:
+                raise ValueError("Deserialization error - duplicate transaction attribute")
+            values.append(attribute)
+        return values

--- a/neo3/network/payloads/verification.py
+++ b/neo3/network/payloads/verification.py
@@ -6,10 +6,14 @@ from neo3.network import payloads
 from typing import List
 
 
-class Cosigner(serialization.ISerializable):
+class Signer(serialization.ISerializable):
     """
     A class that specifies who can pass CheckWitness() verifications in a smart contract.
     """
+
+    #: Maximum number of allowed_contracts or allowed_groups
+    MAX_SUB_ITEMS = 16
+
     def __init__(self, account: types.UInt160 = None,
                  scope: payloads.WitnessScope = None,
                  allowed_contracts: List[types.UInt160] = None,
@@ -17,7 +21,7 @@ class Cosigner(serialization.ISerializable):
         #: The TX sender.
         self.account = account if account else types.UInt160.zero()
         #: payloads.WitnessScope: The configured validation scope.
-        self.scope = scope if scope else payloads.WitnessScope.GLOBAL
+        self.scope = scope if scope else payloads.WitnessScope.FEE_ONLY
         #: List[types.UInt160]: Whitelist of contract hashes if used with
         #: :const:`~neo3.network.payloads.verification.WitnessScope.CUSTOM_CONTRACTS`.
         self.allowed_contracts = allowed_contracts if allowed_contracts else []
@@ -35,6 +39,15 @@ class Cosigner(serialization.ISerializable):
             groups_size = utils.get_var_size(self.allowed_groups)
 
         return s.uint160 + s.uint8 + contracts_size + groups_size
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+        if type(self) != type(other):
+            return False
+        if self.account != other.account:
+            return False
+        return True
 
     def serialize(self, writer: serialization.BinaryWriter) -> None:
         """
@@ -62,11 +75,15 @@ class Cosigner(serialization.ISerializable):
         self.account = reader.read_serializable(types.UInt160)
         self.scope = payloads.WitnessScope(reader.read_uint8())
 
+        if payloads.WitnessScope.GLOBAL in self.scope and self.scope != payloads.WitnessScope.GLOBAL:
+            raise ValueError("Deserialization error - invalid scope. GLOBAL scope not allowed with other scope types")
+
         if payloads.WitnessScope.CUSTOM_CONTRACTS in self.scope:
             self.allowed_contracts = reader.read_serializable_list(types.UInt160)
 
         if payloads.WitnessScope.CUSTOM_GROUPS in self.scope:
-            self.allowed_groups = reader.read_serializable_list(cryptography.EllipticCurve.ECPoint)
+            self.allowed_groups = reader.read_serializable_list(cryptography.EllipticCurve.ECPoint,
+                                                                max=self.MAX_SUB_ITEMS)
 
 
 class Witness(serialization.ISerializable):
@@ -115,15 +132,17 @@ class WitnessScope(IntFlag):
     """
     Determine the rules for a smart contract :func:`CheckWitness()` sys call.
     """
-    #: Allow the witness in all context. Equal to NEO 2.x's default behaviour.
-    GLOBAL = 0x00
+    #: Special case only valid for the first signer in the transaction, a.k.a the sender
+    FEE_ONLY = 0x0
     #: Allow the witness if the current calling script hash equals the entry script hash into the virtual machine.
     #: Using this prevents passing :func:`CheckWitness()` in a smart contract called via another smart contract.
     CALLED_BY_ENTRY = 0x01
-    #: Allow the witness if called from a smart contract that is whitelisted in the cosigner
-    #: :attr:`~neo3.network.payloads.verification.Cosigner.allowed_contracts` attribute.
+    #: Allow the witness if called from a smart contract that is whitelisted in the signer
+    #: :attr:`~neo3.network.payloads.verification.Signer.allowed_contracts` attribute.
     CUSTOM_CONTRACTS = 0x10
-    #: Allow the witness if it any public key in the cosigner
-    #: :attr:`~neo3.network.payloads.verification.Cosigner.allowed_groups` attribute is whitelisted in the contracts
+    #: Allow the witness if any public key is in the signer
+    #: :attr:`~neo3.network.payloads.verification.Signer.allowed_groups` attribute is whitelisted in the contracts
     #: manifest.groups array.
     CUSTOM_GROUPS = 0x20
+    #: Allow the witness in all context. Equal to NEO 2.x's default behaviour.
+    GLOBAL = 0x80

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,13 +2,15 @@ aiodns==2.0.0
 asynctest==0.13.0
 base58==1.0.3
 bitarray==1.0.1
+bitcoin>=1.1.42
 coverage==5.0.2
+ecdsa>=0.15
 Events==0.3
 lz4==2.2.1
 mmh3==2.5.1
-mypy==0.761
+mypy==0.782
 mypy-extensions==0.4.3
-netaddr==0.7.19
+netaddr>=0.8.0
 Sphinx==2.2.0
 sphinx-autodoc-typehints==1.7.0
 plyvel==1.2.0

--- a/tests/network/convenience/test_nodemanager.py
+++ b/tests/network/convenience/test_nodemanager.py
@@ -250,8 +250,8 @@ class NodeManagerTestCase2(asynctest.TestCase):
         # advance loop
         await asyncio.sleep(0.1)
         self.assertTrue(self.nodemgr.is_running)
-        # 3 looping service tasks
-        self.assertEqual(3, len(self.nodemgr.tasks))
+        # 4 looping service tasks
+        self.assertEqual(4, len(self.nodemgr.tasks))
         self.assertIsInstance(call_back_result, node.NeoNode)
         await self.nodemgr.shutdown()
         for t in self.nodemgr.tasks:

--- a/tests/network/test_node.py
+++ b/tests/network/test_node.py
@@ -349,7 +349,7 @@ class NeoNodeTestCase(asynctest.TestCase):
     async def test_send_inventory_and_relay(self):
         # test 2 in 1
         # taken from the Transaction testcase in `test_payloads.py`
-        raw_tx = binascii.unhexlify(b'007B000000DA1745E9B549BD0BFA1A569971C77EBA30CD5A4BC8010000000000001503000000000000010000000181000154A64CAC1B1073E662933EF3E30B007CD98D67D70002010201000155')
+        raw_tx = binascii.unhexlify(b'007B000000C8010000000000001503000000000000010000000154A64CAC1B1073E662933EF3E30B007CD98D67D7000002010201000155')
         tx = payloads.Transaction.deserialize_from_bytes(raw_tx)
 
         n = node.NeoNode(object())

--- a/tests/network/test_payloads.py
+++ b/tests/network/test_payloads.py
@@ -61,8 +61,7 @@ class AddrTestCase(unittest.TestCase):
 
     def test_addrpayload_deserialization2(self):
         capa = capabilities.ServerCapability(n_type=capabilities.NodeCapabilityType.TCPSERVER, port=123)
-        network_addr = payloads.NetworkAddress(address='127.0.0.1:0', timestamp=0,
-                                capabilities=[capa])
+        network_addr = payloads.NetworkAddress(address='127.0.0.1:0', timestamp=0, capabilities=[capa])
         addr_payload = payloads.AddrPayload([network_addr])
 
         deserialized_addr_payload = payloads.AddrPayload.deserialize_from_bytes(addr_payload.to_array())
@@ -124,12 +123,11 @@ class BlockTestCase(unittest.TestCase):
         """
         Transaction tx = new Transaction();
         tx.Nonce = 123;
-        tx.Sender = UInt160.Parse("0x4b5acd30ba7ec77199561afa0bbd49b5e94517da");
         tx.SystemFee = 456;
         tx.NetworkFee = 789;
         tx.ValidUntilBlock = 1;
         tx.Attributes = new TransactionAttribute[0];
-        tx.Cosigners = new Cosigner[0];
+        tx.Signers = new Signer[] { new Signer() { Account = UInt160.Parse("0xe239c7228fa6b46cc0cf43623b2f934301d0b4f7")}};
         tx.Script = new byte[] { 0x1 };
         tx.Witnesses = new Witness[0];
 
@@ -152,15 +150,14 @@ class BlockTestCase(unittest.TestCase):
         Console.WriteLine($"{BitConverter.ToString(b.Trim().ToArray()).Replace("-", "")}");
         """
         cls.tx = payloads.Transaction(version=0,
-                                  nonce=123,
-                                  sender=types.UInt160.from_string("4b5acd30ba7ec77199561afa0bbd49b5e94517da"),
-                                  system_fee=456,
-                                  network_fee=789,
-                                  valid_until_block=1,
-                                  attributes=[],
-                                  cosigners=[],
-                                  script=b'\x01',
-                                  witnesses=[])
+                                      nonce=123,
+                                      system_fee=456,
+                                      network_fee=789,
+                                      valid_until_block=1,
+                                      attributes=[],
+                                      signers=[payloads.Signer(types.UInt160.from_string("e239c7228fa6b46cc0cf43623b2f934301d0b4f7"))],
+                                      script=b'\x01',
+                                      witnesses=[])
 
         cls.block = payloads.Block(version=0,
                                    prev_hash=types.UInt256.from_string("f782c7fbb2eef6afe629b96c0d53fb525eda64ce5345057caf975ac3c2b9ae0a"),
@@ -175,7 +172,7 @@ class BlockTestCase(unittest.TestCase):
 
     def test_len(self):
         # captured from C#, see setUpClass() for the capture code
-        expected_len = 164
+        expected_len = 165
         self.assertEqual(expected_len, len(self.block))
 
     def test_equals(self):
@@ -190,7 +187,7 @@ class BlockTestCase(unittest.TestCase):
 
     def test_serialization(self):
         # captured from C#, see setUpClass() for the capture code
-        expected_data = binascii.unhexlify("000000000AAEB9C2C35A97AF7C054553CE64DA5E52FB530D6CB929E6AFF6EEB2FBC782F7DF3462429C12B5FD6F933AFC90004109B07A5F5BBA5800CCFE5C488EAFD3E9457B000000000000000100000054A64CAC1B1073E662933EF3E30B007CD98D67D70100015502017B00000000000000007B000000DA1745E9B549BD0BFA1A569971C77EBA30CD5A4BC8010000000000001503000000000000010000000000010100")
+        expected_data = binascii.unhexlify("000000000AAEB9C2C35A97AF7C054553CE64DA5E52FB530D6CB929E6AFF6EEB2FBC782F72F9B61E3B410EF24D86B2BAFD9F2611AD8F43A9F7167FC58C3FCCC80BBFD40A67B000000000000000100000054A64CAC1B1073E662933EF3E30B007CD98D67D70100015502017B00000000000000007B000000C80100000000000015030000000000000100000001F7B4D00143932F3B6243CFC06CB4A68F22C739E20000010100")
         self.assertEqual(expected_data, self.block.to_array())
 
     def test_deserialization(self):
@@ -243,7 +240,7 @@ class BlockTestCase(unittest.TestCase):
         expected_len = 178
         self.assertEqual(expected_len, len(trimmed_block))
 
-        expected_data = binascii.unhexlify('000000000AAEB9C2C35A97AF7C054553CE64DA5E52FB530D6CB929E6AFF6EEB2FBC782F7DF3462429C12B5FD6F933AFC90004109B07A5F5BBA5800CCFE5C488EAFD3E9457B000000000000000100000054A64CAC1B1073E662933EF3E30B007CD98D67D70100015502FCAF61CDF5BEF2AB0FFAC66D846D14EDF06C84A0FD852264918E2F1E2E0A546C4E7D2808A695A6A8185846293428D4674056C6FAF63FB117361DAF7719782875017B00000000000000')
+        expected_data = binascii.unhexlify('000000000AAEB9C2C35A97AF7C054553CE64DA5E52FB530D6CB929E6AFF6EEB2FBC782F72F9B61E3B410EF24D86B2BAFD9F2611AD8F43A9F7167FC58C3FCCC80BBFD40A67B000000000000000100000054A64CAC1B1073E662933EF3E30B007CD98D67D70100015502FCAF61CDF5BEF2AB0FFAC66D846D14EDF06C84A0FD852264918E2F1E2E0A546CDBB73FBF82438E317ABA947D8853907AB259BDCEB8A5771AF394371492BD7D88017B00000000000000')
         self.assertEqual(expected_data, trimmed_block.to_array())
 
         deserialized_trimmed_block = payloads.TrimmedBlock.deserialize_from_bytes(trimmed_block.to_array())
@@ -280,6 +277,7 @@ class BlockTestCase(unittest.TestCase):
         self.assertEqual(self.block.consensus_data.primary_index, b.consensus_data.primary_index)
         self.assertEqual(self.block.consensus_data.nonce, b.consensus_data.nonce)
         self.assertEqual(self.block.transactions, b.transactions)
+
 
 class ConsensusDataTestCase(unittest.TestCase):
     @classmethod
@@ -387,11 +385,11 @@ class ConsensusPayloadTestCase(unittest.TestCase):
         self.assertEqual(payloads.InventoryType.CONSENSUS, self.payload.inventory_type)
 
 
-class CosignerTestCase(unittest.TestCase):
+class SignerTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         """
-        Cosigner co = new Cosigner();
+        Signer co = new Signer();
         co.Account = UInt160.Parse("0xd7678dd97c000be3f33e9362e673101bac4ca654");
         co.Scopes = WitnessScope.CustomContracts | WitnessScope.CustomGroups;
         co.AllowedContracts = new UInt160[] { UInt160.Parse("5b7074e873973a6ed3708862f219a6fbf4d1c411") };
@@ -402,31 +400,48 @@ class CosignerTestCase(unittest.TestCase):
         Console.WriteLine($"{co.Size}");
         Console.WriteLine($"{BitConverter.ToString(co.ToArray()).Replace("-","")}");
         """
-        cls.cosigner = payloads.Cosigner()
-        cls.cosigner.account = types.UInt160.from_string("d7678dd97c000be3f33e9362e673101bac4ca654")
-        cls.cosigner.scope = payloads.WitnessScope.CUSTOM_CONTRACTS | payloads.WitnessScope.CUSTOM_GROUPS
-        cls.cosigner.allowed_contracts = [types.UInt160.from_string("5b7074e873973a6ed3708862f219a6fbf4d1c411")]
+        cls.signer = payloads.Signer()
+        cls.signer.account = types.UInt160.from_string("d7678dd97c000be3f33e9362e673101bac4ca654")
+        cls.signer.scope = payloads.WitnessScope.CUSTOM_CONTRACTS | payloads.WitnessScope.CUSTOM_GROUPS
+        cls.signer.allowed_contracts = [types.UInt160.from_string("5b7074e873973a6ed3708862f219a6fbf4d1c411")]
         ecdsa = crypto.ECDSA.decode_secp256r1("026241e7e26b38bb7154b8ad49458b97fb1c4797443dc921c5ca5774f511a2bbfc")
         point = ecdsa.G  # type: crypto.EllipticCurve.ECPoint
-        cls.cosigner.allowed_groups = [point]
+        cls.signer.allowed_groups = [point]
 
     def test_len(self):
         # captured from C#, see setUpClass() for the capture code
         expected_len = 76
-        self.assertEqual(expected_len, len(self.cosigner))
+        self.assertEqual(expected_len, len(self.signer))
+
+    def test_equals(self):
+        self.assertFalse(self.signer == None)
+        self.assertFalse(self.signer == object())
+        signer2 = payloads.Signer()
+        self.assertFalse(self.signer == signer2)
+        self.assertTrue(self.signer == self.signer)
 
     def test_serialization(self):
         # captured from C#, see setUpClass() for the capture code
         expected_data = binascii.unhexlify(b'54A64CAC1B1073E662933EF3E30B007CD98D67D7300111C4D1F4FBA619F2628870D36E3A9773E874705B01026241E7E26B38BB7154B8AD49458B97FB1C4797443DC921C5CA5774F511A2BBFC')
-        self.assertEqual(expected_data, self.cosigner.to_array())
+        self.assertEqual(expected_data, self.signer.to_array())
 
     def test_deserialization(self):
         # if the serialization() test for this class passes, we can use that as a reference to test deserialization against
-        deserialized_cosigner = payloads.Cosigner.deserialize_from_bytes(self.cosigner.to_array())
-        self.assertEqual(self.cosigner.account, deserialized_cosigner.account)
-        self.assertEqual(self.cosigner.scope, deserialized_cosigner.scope)
-        self.assertEqual(self.cosigner.allowed_contracts, deserialized_cosigner.allowed_contracts)
-        self.assertEqual(self.cosigner.allowed_groups, deserialized_cosigner.allowed_groups)
+        deserialized_signer = payloads.Signer.deserialize_from_bytes(self.signer.to_array())
+        self.assertEqual(self.signer.account, deserialized_signer.account)
+        self.assertEqual(self.signer.scope, deserialized_signer.scope)
+        self.assertEqual(self.signer.allowed_contracts, deserialized_signer.allowed_contracts)
+        self.assertEqual(self.signer.allowed_groups, deserialized_signer.allowed_groups)
+
+    def test_deserialization_invalid_scope(self):
+        data = bytearray(self.signer.to_array())
+        # the scope is serialized after the UInt160 `account` attribute
+        # we modify that byte to an invalid scope type
+        data[20] = 0xFF
+
+        with self.assertRaises(ValueError) as context:
+            payloads.Signer.deserialize_from_bytes(data)
+        self.assertEqual("Deserialization error - invalid scope. GLOBAL scope not allowed with other scope types", str(context.exception))
 
 
 class FilterAddTestCase(unittest.TestCase):
@@ -763,12 +778,11 @@ class MerkleBlockPayloadTestCase(unittest.TestCase):
         """
         Transaction tx = new Transaction();
         tx.Nonce = 123;
-        tx.Sender = UInt160.Parse("0x4b5acd30ba7ec77199561afa0bbd49b5e94517da");
         tx.SystemFee = 456;
         tx.NetworkFee = 789;
         tx.ValidUntilBlock = 1;
         tx.Attributes = new TransactionAttribute[0];
-        tx.Cosigners = new Cosigner[0];
+        tx.Signers = new Signer[] { new Signer() { Account = UInt160.Parse("0xe239c7228fa6b46cc0cf43623b2f934301d0b4f7")}};
         tx.Script = new byte[] { 0x1 };
         tx.Witnesses = new Witness[0];
 
@@ -791,15 +805,14 @@ class MerkleBlockPayloadTestCase(unittest.TestCase):
         Console.WriteLine($"b\'{BitConverter.ToString(mbp.ToArray()).Replace("-", "")}\'");
         """
         cls.tx = payloads.Transaction(version=0,
-                                  nonce=123,
-                                  sender=types.UInt160.from_string("4b5acd30ba7ec77199561afa0bbd49b5e94517da"),
-                                  system_fee=456,
-                                  network_fee=789,
-                                  valid_until_block=1,
-                                  attributes=[],
-                                  cosigners=[],
-                                  script=b'\x01',
-                                  witnesses=[])
+                                      nonce=123,
+                                      system_fee=456,
+                                      network_fee=789,
+                                      valid_until_block=1,
+                                      attributes=[],
+                                      signers=[payloads.Signer(types.UInt160.from_string("e239c7228fa6b46cc0cf43623b2f934301d0b4f7"))],
+                                      script=b'\x01',
+                                      witnesses=[])
 
         cls.block = payloads.Block(version=0,
                                    prev_hash=types.UInt256.from_string("f782c7fbb2eef6afe629b96c0d53fb525eda64ce5345057caf975ac3c2b9ae0a"),
@@ -821,7 +834,7 @@ class MerkleBlockPayloadTestCase(unittest.TestCase):
 
     def test_serialization(self):
         # captured from C#, see setUpClass() for the capture code
-        expected_data = binascii.unhexlify(b'000000000AAEB9C2C35A97AF7C054553CE64DA5E52FB530D6CB929E6AFF6EEB2FBC782F7DF3462429C12B5FD6F933AFC90004109B07A5F5BBA5800CCFE5C488EAFD3E9457B000000000000000100000054A64CAC1B1073E662933EF3E30B007CD98D67D7010001550202FCAF61CDF5BEF2AB0FFAC66D846D14EDF06C84A0FD852264918E2F1E2E0A546C4E7D2808A695A6A8185846293428D4674056C6FAF63FB117361DAF7719782875020102')
+        expected_data = binascii.unhexlify(b'000000000AAEB9C2C35A97AF7C054553CE64DA5E52FB530D6CB929E6AFF6EEB2FBC782F72F9B61E3B410EF24D86B2BAFD9F2611AD8F43A9F7167FC58C3FCCC80BBFD40A67B000000000000000100000054A64CAC1B1073E662933EF3E30B007CD98D67D7010001550202FCAF61CDF5BEF2AB0FFAC66D846D14EDF06C84A0FD852264918E2F1E2E0A546CDBB73FBF82438E317ABA947D8853907AB259BDCEB8A5771AF394371492BD7D88020102')
         self.assertEqual(expected_data, self.merkle_payload.to_array())
 
     def test_deserialization(self):
@@ -867,33 +880,95 @@ class PingTestCase(unittest.TestCase):
         self.assertEqual(self.ping.current_height, deserialized_ping.current_height)
 
 
+class TestTXAttribute(payloads.TransactionAttribute):
+    def __init__(self):
+        super(TestTXAttribute, self).__init__()
+        self.type_ = 0
+        self.test_member = True
+
+    def __len__(self):
+        size_bool = 1
+        return super(TestTXAttribute, self).__len__() + size_bool
+
+    def _deserialize_without_type(self, reader: serialization.BinaryReader) -> None:
+        self.test_member = reader.read_bool()
+
+    def _serialize_without_type(self, writer: serialization.BinaryWriter) -> None:
+        writer.write_bool(self.test_member)
+
+
 class TransactionAttributeTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         """
-        TransactionAttribute ta = new TransactionAttribute();
-        ta.Usage = TransactionAttributeUsage.Url;
-        ta.Data = new byte[] { 0x1, 0x2 };
+        Requires a custom attribute
+
+        class TestTXAttribute : TransactionAttribute
+        {
+            public override TransactionAttributeType Type { get; }
+            public override bool AllowMultiple { get => true; }
+
+            public bool test_member = true;
+
+            public override int Size { get => base.Size + sizeof(bool); }
+
+            protected override void DeserializeWithoutType(BinaryReader reader)
+            {
+                test_member = reader.ReadBoolean();
+            }
+
+            protected override void SerializeWithoutType(BinaryWriter writer)
+            {
+                writer.Write(test_member);
+            }
+        }
+
+        TransactionAttribute ta = new TestTXAttribute();
         Console.WriteLine($"{ta.Size}");
         Console.WriteLine($"{BitConverter.ToString(ta.ToArray()).Replace("-", "")}");
         """
-        cls.attribute = payloads.TransactionAttribute(payloads.TransactionAttributeUsage.URL, b'\x01\x02')
+        cls.attribute = TestTXAttribute()
 
     def test_len(self):
         # captured from C#, see setUpClass() for the capture code
-        expected_len = 4
+        expected_len = 2
         self.assertEqual(expected_len, len(self.attribute))
+
+    def test_equals(self):
+        self.assertFalse(self.attribute == None)
+        self.assertFalse(self.attribute == object())
+        self.assertTrue(self.attribute == TestTXAttribute())
 
     def test_serialization(self):
         # captured from C#, see setUpClass() for the capture code
-        expected_data = binascii.unhexlify(b'81020102')
+        expected_data = binascii.unhexlify(b'0001')
         self.assertEqual(expected_data, self.attribute.to_array())
 
     def test_deserialization(self):
         # if the serialization() test for this class passes, we can use that as a reference to test deserialization against
         deserialized_attribute = self.attribute.deserialize_from_bytes(self.attribute.to_array())
-        self.assertEqual(self.attribute.usage, deserialized_attribute.usage)
-        self.assertEqual(self.attribute.data, deserialized_attribute.data)
+        self.assertEqual(self.attribute.type_, deserialized_attribute.type_)
+        self.assertEqual(self.attribute.test_member, deserialized_attribute.test_member)
+
+    def test_deserialization_wrong_type(self):
+        stream_with_type_one = b'\x01'
+        attribute = TestTXAttribute()
+        with self.assertRaises(ValueError) as context:
+            attribute.deserialize_from_bytes(stream_with_type_one)
+        self.assertEqual("Deserialization error - transaction attribute type mismatch", str(context.exception))
+
+    def test_deserialization_from(self):
+        stream_with_type_zero = b'\x00\x01'
+        with serialization.BinaryReader(stream_with_type_zero) as reader:
+            ta = payloads.TransactionAttribute.deserialize_from(reader)
+        self.assertIsInstance(ta, TestTXAttribute)
+
+    def test_deserialization_from_failure(self):
+        stream_with_invalid_type = b'\xFF'
+        with serialization.BinaryReader(stream_with_invalid_type) as reader:
+            with self.assertRaises(ValueError) as context:
+                payloads.TransactionAttribute.deserialize_from(reader)
+            self.assertEqual("Deserialization error - unknown transaction attribute type", str(context.exception))
 
 
 class TransactionTestCase(unittest.TestCase):
@@ -902,17 +977,15 @@ class TransactionTestCase(unittest.TestCase):
         """
         Transaction tx = new Transaction();
         tx.Nonce = 123;
-        tx.Sender = UInt160.Parse("0x4b5acd30ba7ec77199561afa0bbd49b5e94517da");
-        Console.WriteLine($"{tx.Sender.ToString()}");
         tx.SystemFee = 456;
         tx.NetworkFee = 789;
         tx.ValidUntilBlock = 1;
-        tx.Attributes = new TransactionAttribute[] { new TransactionAttribute { Usage=TransactionAttributeUsage.Url, Data=new byte[0] } };
+        tx.Attributes = new TransactionAttribute[] { };
 
-        Cosigner co = new Cosigner();
+        Signer co = new Signer();
         co.Account = UInt160.Parse("0xd7678dd97c000be3f33e9362e673101bac4ca654");
-        co.Scopes = WitnessScope.Global;
-        tx.Cosigners = new Cosigner[] { co };
+        co.Scopes = WitnessScope.FeeOnly;
+        tx.Signers = new Signer[] { co };
 
         tx.Script = new byte[] { 0x1, 0x2 };
         tx.Witnesses = new Witness[] { new Witness { InvocationScript=new byte[0], VerificationScript = new byte[] { 0x55 } } };
@@ -922,34 +995,34 @@ class TransactionTestCase(unittest.TestCase):
         Console.WriteLine(tx.Hash);
         Console.WriteLine(tx.FeePerByte);
         """
-        attribute = payloads.TransactionAttribute(payloads.TransactionAttributeUsage.URL, b'')
-
-        cosigner = payloads.Cosigner(account=types.UInt160.from_string("d7678dd97c000be3f33e9362e673101bac4ca654"),
-                                     scope=payloads.WitnessScope.GLOBAL)
+        signer = payloads.Signer(account=types.UInt160.from_string("d7678dd97c000be3f33e9362e673101bac4ca654"),
+                                   scope=payloads.WitnessScope.FEE_ONLY)
 
         witness = payloads.Witness(invocation_script=b'', verification_script=b'\x55')
 
         cls.tx = payloads.Transaction(version=0,
-                                  nonce=123,
-                                  sender=types.UInt160.from_string("4b5acd30ba7ec77199561afa0bbd49b5e94517da"),
-                                  system_fee=456,
-                                  network_fee=789,
-                                  valid_until_block=1,
-                                  attributes=[attribute],
-                                  cosigners=[cosigner],
-                                  script=b'\x01\x02',
-                                  witnesses=[witness])
+                                      nonce=123,
+                                      system_fee=456,
+                                      network_fee=789,
+                                      valid_until_block=1,
+                                      attributes=[],
+                                      signers=[signer],
+                                      script=b'\x01\x02',
+                                      witnesses=[witness])
+
+    def tearDown(cls) -> None:
+        settings.reset_settings_to_default()
 
     def test_len_and_hash(self):
         # captured from C#, see setUpClass() for the capture code
-        expected_len = 77
-        expected_hash = types.UInt256.from_string('e8dcae85d7a5d3965da7f07ab7bd48968a8a9021b8826c91bee5cb14431b6970')
+        expected_len = 55
+        expected_hash = types.UInt256.from_string('175cdc35664fc27e09b1970f190b6dce41d82c5409882e74c395f57de5c84ecd')
         self.assertEqual(expected_len, len(self.tx))
         self.assertEqual(expected_hash, self.tx.hash())
 
     def test_serialization(self):
         # captured from C#, see setUpClass() for the capture code
-        expected_data = binascii.unhexlify(b'007B000000DA1745E9B549BD0BFA1A569971C77EBA30CD5A4BC8010000000000001503000000000000010000000181000154A64CAC1B1073E662933EF3E30B007CD98D67D70002010201000155')
+        expected_data = binascii.unhexlify(b'007B000000C8010000000000001503000000000000010000000154A64CAC1B1073E662933EF3E30B007CD98D67D7000002010201000155')
         self.assertEqual(expected_data, self.tx.to_array())
 
     def test_deserialization(self):
@@ -957,16 +1030,13 @@ class TransactionTestCase(unittest.TestCase):
         deserialized_tx = payloads.Transaction.deserialize_from_bytes(self.tx.to_array())
         self.assertEqual(self.tx.version, deserialized_tx.version)
         self.assertEqual(self.tx.nonce, deserialized_tx.nonce)
-        self.assertEqual(self.tx.sender, deserialized_tx.sender)
         self.assertEqual(self.tx.system_fee, deserialized_tx.system_fee)
         self.assertEqual(self.tx.network_fee, deserialized_tx.network_fee)
         self.assertEqual(self.tx.valid_until_block, deserialized_tx.valid_until_block)
         self.assertEqual(len(self.tx.attributes), len(deserialized_tx.attributes))
-        self.assertEqual(self.tx.attributes[0].usage, deserialized_tx.attributes[0].usage)
-        self.assertEqual(self.tx.attributes[0].data, deserialized_tx.attributes[0].data)
-        self.assertEqual(len(self.tx.cosigners), len(deserialized_tx.cosigners))
-        self.assertEqual(self.tx.cosigners[0].account, deserialized_tx.cosigners[0].account)
-        self.assertEqual(self.tx.cosigners[0].scope, deserialized_tx.cosigners[0].scope)
+        self.assertEqual(len(self.tx.signers), len(deserialized_tx.signers))
+        self.assertEqual(self.tx.signers[0].account, deserialized_tx.signers[0].account)
+        self.assertEqual(self.tx.signers[0].scope, deserialized_tx.signers[0].scope)
         self.assertEqual(self.tx.script, deserialized_tx.script)
         self.assertEqual(len(self.tx.witnesses), len(deserialized_tx.witnesses))
         self.assertEqual(self.tx.witnesses[0].invocation_script, deserialized_tx.witnesses[0].invocation_script)
@@ -1000,9 +1070,38 @@ class TransactionTestCase(unittest.TestCase):
             payloads.Transaction.deserialize_from_bytes(tx.to_array())
         self.assertEqual("Deserialization error - invalid script length 0", str(context.exception))
 
+    def test_deserialization_duplicate_attribute_error(self):
+        tx = deepcopy(self.tx)
+        tx.attributes = [TestTXAttribute(), TestTXAttribute()]
+        with self.assertRaises(ValueError) as context:
+            payloads.Transaction.deserialize_from_bytes(tx.to_array())
+        self.assertEqual("Deserialization error - duplicate transaction attribute", str(context.exception))
+
+    def test_deserialization_empty_signers_error(self):
+        tx = deepcopy(self.tx)
+        tx.signers = []
+        with self.assertRaises(ValueError) as context:
+            payloads.Transaction.deserialize_from_bytes(tx.to_array())
+        self.assertEqual("Deserialization error - signers can't be empty", str(context.exception))
+
+    def test_deserialization_multiple_feeonly_in_signers_list_error(self):
+        tx = deepcopy(self.tx)
+        tx.signers.append(deepcopy(tx.signers[0]))
+        with self.assertRaises(ValueError) as context:
+            payloads.Transaction.deserialize_from_bytes(tx.to_array())
+        self.assertEqual("Deserialization error - only the first signer can be fee only", str(context.exception))
+
+    def test_deserialization_duplicate_signer(self):
+        tx = deepcopy(self.tx)
+        tx.signers[0].scope = payloads.WitnessScope.GLOBAL
+        tx.signers.append(deepcopy(tx.signers[0]))
+        with self.assertRaises(ValueError) as context:
+            payloads.Transaction.deserialize_from_bytes(tx.to_array())
+        self.assertEqual("Deserialization error - duplicate signer", str(context.exception))
+
     def test_fee_per_byte(self):
         # captured from C#, see setUpClass() for the capture code
-        expected_fee = 10
+        expected_fee = 14
         self.assertEqual(expected_fee, self.tx.fee_per_byte())
 
     def test_equals(self):
@@ -1023,16 +1122,13 @@ class TransactionTestCase(unittest.TestCase):
         t.from_replica(self.tx)
         self.assertEqual(self.tx.version, t.version)
         self.assertEqual(self.tx.nonce, t.nonce)
-        self.assertEqual(self.tx.sender, t.sender)
         self.assertEqual(self.tx.system_fee, t.system_fee)
         self.assertEqual(self.tx.network_fee, t.network_fee)
         self.assertEqual(self.tx.valid_until_block, t.valid_until_block)
         self.assertEqual(len(self.tx.attributes), len(t.attributes))
-        self.assertEqual(self.tx.attributes[0].usage, t.attributes[0].usage)
-        self.assertEqual(self.tx.attributes[0].data, t.attributes[0].data)
-        self.assertEqual(len(self.tx.cosigners), len(t.cosigners))
-        self.assertEqual(self.tx.cosigners[0].account, t.cosigners[0].account)
-        self.assertEqual(self.tx.cosigners[0].scope, t.cosigners[0].scope)
+        self.assertEqual(len(self.tx.signers), len(t.signers))
+        self.assertEqual(self.tx.signers[0].account, t.signers[0].account)
+        self.assertEqual(self.tx.signers[0].scope, t.signers[0].scope)
         self.assertEqual(self.tx.script, t.script)
         self.assertEqual(len(self.tx.witnesses), len(t.witnesses))
         self.assertEqual(self.tx.witnesses[0].invocation_script, t.witnesses[0].invocation_script)
@@ -1048,6 +1144,28 @@ class TransactionTestCase(unittest.TestCase):
             tx_from_bytes = payloads.Transaction()
             tx_from_bytes.deserialize_special(br)
         self.assertEqual(tx_special.block_height, tx_from_bytes.block_height)
+
+    def test_sender(self):
+        self.assertEqual(self.tx.signers[0].account, self.tx.sender)
+
+        tx = deepcopy(self.tx)
+        tx.signers = []
+        with self.assertRaises(ValueError) as context:
+            tx.sender
+        self.assertEqual("Invalid transaction - signers can't be empty", str(context.exception))
+
+    def test_protocol_magic(self):
+        # test proper initialization
+        tx = payloads.Transaction()
+        # test default
+        self.assertEqual(0x4F454E, tx.protocol_magic)
+        # test init supplied
+        tx = payloads.Transaction(protocol_magic=123)
+        self.assertEqual(123, tx.protocol_magic)
+        # test settings supplied
+        settings.network.magic = 456
+        tx = payloads.Transaction()
+        self.assertEqual(456, tx.protocol_magic)
 
 
 class VersionTestCase(unittest.TestCase):
@@ -1131,3 +1249,12 @@ class WitnessTestCase(unittest.TestCase):
         deserialized_witness = payloads.Witness.deserialize_from_bytes(self.witness.to_array())
         self.assertEqual(self.witness.verification_script, deserialized_witness.verification_script)
         self.assertEqual(self.witness.invocation_script, deserialized_witness.invocation_script)
+
+
+class EmptyPayloadTestCase(unittest.TestCase):
+    def test_empty(self):
+        e = payloads.EmptyPayload()
+        self.assertEqual(0, len(e))
+        self.assertEqual(0, len(e.to_array()))
+        bogus_data = b'\x01\x02\x03'
+        self.assertIsInstance(payloads.EmptyPayload.deserialize_from_bytes(bogus_data), payloads.EmptyPayload)

--- a/tests/storage/storagetest.py
+++ b/tests/storage/storagetest.py
@@ -31,14 +31,15 @@ class AbstractBlockStorageTest(abc.ABC, unittest.TestCase):
 
     def setUp(self) -> None:
         self.db = self.db_factory()
+        signer = payloads.Signer(account=types.UInt160.from_string("d7678dd97c000be3f33e9362e673101bac4ca654"),
+                                 scope=payloads.WitnessScope.FEE_ONLY)
         tx = payloads.Transaction(version=0,
                                   nonce=123,
-                                  sender=types.UInt160.from_string("4b5acd30ba7ec77199561afa0bbd49b5e94517da"),
                                   system_fee=456,
                                   network_fee=789,
                                   valid_until_block=1,
                                   attributes=[],
-                                  cosigners=[],
+                                  signers=[signer],
                                   script=b'\x01',
                                   witnesses=[])
 
@@ -271,7 +272,7 @@ class AbstractBlockStorageTest(abc.ABC, unittest.TestCase):
         snapshot_view = self.db.get_snapshotview()
 
         # get() a block to fill the cache so we can test sorting and readonly behaviour
-        # block2's hash comes before block1 when sorting. So we cache that first as the all() internals
+        # block2's hash comes before block1 when sorting. So we cache that first as the all() function internals
         # collect the results from the backend (=block1) before results from the cache (=block2).
         # Therefore if block2 is found in the first position of the all() results, we can
         # conclude that the sort() happened correctly.
@@ -299,9 +300,9 @@ class AbstractBlockStorageTest(abc.ABC, unittest.TestCase):
         blocks = list(clone_view.blocks.all())
         self.assertEqual(3, len(blocks))
         self.assertEqual(2, len(list(snapshot_view.blocks.all())))
+        self.assertEqual(self.block2, blocks[0])
+        self.assertEqual(block3, blocks[1])
         self.assertEqual(self.block1, blocks[2])
-        self.assertEqual(self.block2, blocks[1])
-        self.assertEqual(block3, blocks[0])
 
     def test_snapshot_bestblockheight(self):
         snapshot_view = self.db.get_snapshotview()
@@ -1125,21 +1126,19 @@ class AbstractTransactionStorageTest(abc.ABC, unittest.TestCase):
 
     def setUp(self) -> None:
         self.db = self.db_factory()
-        attribute = payloads.TransactionAttribute(payloads.TransactionAttributeUsage.URL, b'')
 
-        cosigner = payloads.Cosigner(account=types.UInt160.from_string("d7678dd97c000be3f33e9362e673101bac4ca654"),
-                                     scope=payloads.WitnessScope.GLOBAL)
+        cosigner = payloads.Signer(account=types.UInt160.from_string("d7678dd97c000be3f33e9362e673101bac4ca654"),
+                                   scope=payloads.WitnessScope.GLOBAL)
 
         witness = payloads.Witness(invocation_script=b'', verification_script=b'\x55')
 
         self.tx1 = payloads.Transaction(version=0,
                                         nonce=123,
-                                        sender=types.UInt160.from_string("4b5acd30ba7ec77199561afa0bbd49b5e94517da"),
                                         system_fee=456,
                                         network_fee=789,
                                         valid_until_block=1,
-                                        attributes=[attribute],
-                                        cosigners=[cosigner],
+                                        attributes=[],
+                                        signers=[cosigner],
                                         script=b'\x01\x02',
                                         witnesses=[witness])
 


### PR DESCRIPTION
- close #9
- improve syncing speed when the local chain is ~in sync with the remote node. Previously the C# nodes broadcasted new blocks faster, now we can lag behind 2-3 seconds. Added a service in node manager to ping remote nodes on a interval to be aware of their new heights faster. 