### PR TITLE
Limit documentation publishing step to master only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,12 +106,13 @@ workflows:
           requires:
             - setup-environment
   update-docs:
-    branches:
-      only:
-        - master
     jobs:
       - approve-update:
           type: approval
+          filters:
+            branches:
+              only:
+                - master
       - setup-environment:
           requires:
             - approve-update

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,9 @@ workflows:
           requires:
             - setup-environment
   update-docs:
+    branches:
+      only:
+        - master
     jobs:
       - approve-update:
           type: approval


### PR DESCRIPTION
Circle-ci is currently setup to require approval on documentation publishing for all branches. This has the effect that either all pull requests will not receive the ✅  because we don't approve the documentation publishing, or the documentation will be approved which will update the live documentation while the documentation changes might only apply to the development version.