### PR TITLE
Simplify working with storage states

### DIFF
--- a/neo3/contracts/interop/contract.py
+++ b/neo3/contracts/interop/contract.py
@@ -105,11 +105,11 @@ def contract_call_internal(engine: contracts.ApplicationEngine,
     if method.startswith('_'):
         raise ValueError("[System.Contract.Call] Method not allowed to start with _")
 
-    target_contract = engine.snapshot.contracts.try_get(contract_hash)
+    target_contract = engine.snapshot.contracts.try_get(contract_hash, read_only=True)
     if target_contract is None:
         raise ValueError("[System.Contract.Call] Can't find target contract")
 
-    current_contract = engine.snapshot.contracts.try_get(engine.current_scripthash)
+    current_contract = engine.snapshot.contracts.try_get(engine.current_scripthash, read_only=True)
     if current_contract and not current_contract.manifest.can_call(target_contract.manifest, method):
         raise ValueError(f"[System.Contract.Call] Not allowed to call target method '{method}' according to manifest")
 

--- a/neo3/contracts/interop/storage.py
+++ b/neo3/contracts/interop/storage.py
@@ -11,7 +11,7 @@ MAX_STORAGE_VALUE_SIZE = 65535
 
 @register("System.Storage.GetContext", 400, contracts.native.CallFlags.ALLOW_STATES, False, [])
 def get_context(engine: contracts.ApplicationEngine) -> storage.StorageContext:
-    contract = engine.snapshot.contracts.try_get(engine.current_scripthash)
+    contract = engine.snapshot.contracts.try_get(engine.current_scripthash, read_only=True)
     if not contract.has_storage:
         raise ValueError("Cannot get context for smart contract without storage")
     return storage.StorageContext(engine.current_scripthash, False)
@@ -19,7 +19,7 @@ def get_context(engine: contracts.ApplicationEngine) -> storage.StorageContext:
 
 @register("System.Storage.GetReadOnlyContext", 400, contracts.native.CallFlags.ALLOW_STATES, False, [])
 def get_read_only_context(engine: contracts.ApplicationEngine) -> storage.StorageContext:
-    contract = engine.snapshot.contracts.try_get(engine.current_scripthash)
+    contract = engine.snapshot.contracts.try_get(engine.current_scripthash, read_only=True)
     if not contract.has_storage:
         raise ValueError("Cannot get context for smart contract without storage")
     return storage.StorageContext(contract.script_hash(), True)

--- a/neo3/storage/storageitem.py
+++ b/neo3/storage/storageitem.py
@@ -45,24 +45,49 @@ class StorageItem(serialization.ISerializable, IClonable):
 
 
 class Nep5StorageState(IInteroperable, serialization.ISerializable):
+    """
+    Helper class for NEP5 balance state
+
+    Use the from_storage() method if you're working with a DB snapshot and intend to modify the state values.
+    It will ensure that the cache is updated automatically.
+    """
+
     def __init__(self):
         super(Nep5StorageState, self).__init__()
-        self.balance: vm.BigInteger = vm.BigInteger.zero()
+        self._balance: vm.BigInteger = vm.BigInteger.zero()
+        self._storage_item = StorageItem(b'')
 
     def __len__(self):
-        return len(self.balance.to_array())
+        return len(self._balance.to_array())
+
+    @classmethod
+    def from_storage(cls, storage_item: StorageItem):
+        state = cls()
+        state._storage_item = storage_item
+        with serialization.BinaryReader(storage_item.value) as reader:
+            state.deserialize(reader)
+        return state
+
+    @property
+    def balance(self) -> vm.BigInteger:
+        return self._balance
+
+    @balance.setter
+    def balance(self, value: vm.BigInteger) -> None:
+        self._balance = value
+        self._storage_item.value = self.to_array()
 
     def serialize(self, writer: BinaryWriter) -> None:
-        writer.write_var_bytes(self.balance.to_array())
+        writer.write_var_bytes(self._balance.to_array())
 
     def deserialize(self, reader: BinaryReader) -> None:
-        self.balance = vm.BigInteger(reader.read_var_bytes())
+        self._balance = vm.BigInteger(reader.read_var_bytes())
 
     def to_stack_item(self, reference_counter: vm.ReferenceCounter) -> vm.StackItem:
         s = vm.StructStackItem(reference_counter)
-        s.append(vm.IntegerStackItem(self.balance))
+        s.append(vm.IntegerStackItem(self._balance))
         return s
 
     def from_stack_item(self, stack_item: vm.StackItem) -> None:
         si = cast(vm.StructStackItem, stack_item)
-        self.balance = si[0].to_biginteger()
+        self._balance = si[0].to_biginteger()


### PR DESCRIPTION
1) Working with storage states was prone to forgetting to persist the changes back into the storage item if accessed via snapshots. This change takes care of automatically doing this.
2) limit some contract state readings to be readonly (avoids them being reported as deviating from C# during audit as they haven't actually changed)