### PR TITLE
Change UInt initialization

### DIFF
--- a/neo3/core/types/uint.py
+++ b/neo3/core/types/uint.py
@@ -17,28 +17,10 @@ class _UIntBase(serialization.ISerializable):
         super(_UIntBase, self).__init__()
 
         if data is None:
-            self._data = bytearray(num_bytes)
+            self._data = bytes(num_bytes)
 
         else:
-            if isinstance(data, bytes):
-                # make sure it's mutable for string representation
-                self._data = bytearray(data)
-            elif isinstance(data, bytearray):
-                self._data = data
-            else:
-                raise TypeError(f"Invalid data type {type(data)}. Expecting bytes or bytearray")
-
-            # now make sure the sequence is hex escaped
-            try:
-                self._data = bytearray(binascii.unhexlify(self._data.decode()))
-            except UnicodeDecodeError:
-                # decode() fails most of the time if data is already hex escaped.
-                # In that case there is nothing to be done.
-                pass
-            except binascii.Error:
-                # however in some cases like bytes.fromhex('1122') decoding passes,
-                # but binascii fails because it was actually already escaped. Still nothing to be done.
-                pass
+            self._data = data
 
             if len(self._data) != num_bytes:
                 raise ValueError(f"Invalid UInt: data length {len(self._data)} != specified num_bytes {num_bytes}")
@@ -172,7 +154,7 @@ class UInt160(_UIntBase):
         Returns:
             An instance initialized to zero.
         """
-        return cls(data=bytearray(20))
+        return cls(data=bytes(20))
 
     def serialize(self, writer: serialization.BinaryWriter) -> None:
         """
@@ -190,7 +172,7 @@ class UInt160(_UIntBase):
         Args:
             reader: instance.
         """
-        self._data = bytearray(reader.read_bytes(self._BYTE_LEN))
+        self._data = bytes(reader.read_bytes(self._BYTE_LEN))
 
 
 class UInt256(_UIntBase):
@@ -248,7 +230,7 @@ class UInt256(_UIntBase):
             An instance initialized to zero.
         """
 
-        return cls(data=bytearray(cls._BYTE_LEN))
+        return cls(data=bytes(cls._BYTE_LEN))
 
     def serialize(self, writer: serialization.BinaryWriter) -> None:
         """
@@ -266,4 +248,4 @@ class UInt256(_UIntBase):
         Args:
             reader: instance.
         """
-        self._data = bytearray(reader.read_bytes(self._BYTE_LEN))
+        self._data = bytes(reader.read_bytes(self._BYTE_LEN))

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -19,25 +19,10 @@ class UIntBaseTest(TestCase):
         self.assertEqual(len(x._data), 2)
         self.assertEqual(x._data, b'\x00\x00')
 
-    def test_valid_data(self):
-        x = UIntBase(num_bytes=2, data=b'aabb')
-        # test for proper conversion to raw bytes
-        self.assertEqual(len(x._data), 2)
-        self.assertNotEqual(len(x._data), 4)
-
-        x = UIntBase(num_bytes=3, data=bytearray.fromhex('aabbcc'))
-        self.assertEqual(len(x._data), 3)
-        self.assertNotEqual(len(x._data), 6)
-
     def test_valid_rawbytes_data(self):
         x = UIntBase(num_bytes=2, data=b'\xaa\xbb')
         self.assertEqual(len(x._data), 2)
         self.assertNotEqual(len(x._data), 4)
-
-    def test_invalid_data_type(self):
-        with self.assertRaises(TypeError) as context:
-            x = UIntBase(num_bytes=2, data='abc')
-        self.assertTrue("Invalid data type" in str(context.exception))
 
     def test_raw_data_that_can_be_decoded(self):
         """
@@ -49,7 +34,7 @@ class UIntBaseTest(TestCase):
 
     def test_data_length_mistmatch(self):
         with self.assertRaises(ValueError) as context:
-            x = UIntBase(num_bytes=2, data=b'aa')  # 2 != 1
+            x = UIntBase(num_bytes=2, data=b'a')  # 2 != 1
         self.assertTrue("Invalid UInt: data length" in str(context.exception))
 
     def test_size(self):
@@ -121,6 +106,7 @@ class UIntBaseTest(TestCase):
         self.assertTrue(z > x)
         self.assertTrue(x <= xx)
         self.assertTrue(x >= xx)
+
 
 class UInt160_and_256Test(TestCase):
     def test_zero(self):


### PR DESCRIPTION
The UInt types are used a lot around in the NEO system. In just the first 5000 blocks they're created over 86_000 times. The initialization code protects against users initializing them without hex-escaped values, but it is considered too expensive. This changes speeds it up 3x