### PR TITLE
Fast validators

### DIFF
--- a/neo3/blockchain.py
+++ b/neo3/blockchain.py
@@ -16,8 +16,6 @@ class Blockchain(convenience._Singleton):
         self.genesis_block.rebuild_merkle_root()
 
         sb = vm.ScriptBuilder()
-        # do not change the order of contracts. GAS must be called first.
-        # This allows for a on_persist() performance speed up
         for c in [contracts.GasToken(), contracts.NeoToken()]:
             sb.emit_contract_call(c.script_hash, "onPersist")  # type: ignore
             sb.emit(vm.OpCode.DROP)

--- a/neo3/blockchain.py
+++ b/neo3/blockchain.py
@@ -16,6 +16,8 @@ class Blockchain(convenience._Singleton):
         self.genesis_block.rebuild_merkle_root()
 
         sb = vm.ScriptBuilder()
+        # do not change the order of contracts. GAS must be called first.
+        # This allows for a on_persist() performance speed up
         for c in [contracts.GasToken(), contracts.NeoToken()]:
             sb.emit_contract_call(c.script_hash, "onPersist")  # type: ignore
             sb.emit(vm.OpCode.DROP)


### PR DESCRIPTION
For every block produced the validators are read from disk, sorted and persisted. These validators are `ECPoint` objects and they're very expensive to deserialize. By caching the deserialized points we get a 62% speed gain during chain syncing