### PR TITLE
fix requesting headers

### DIFF
--- a/neo3/network/node.py
+++ b/neo3/network/node.py
@@ -425,18 +425,18 @@ class NeoNode:
                             payload=payloads.AddrPayload(addresses=network_addresses))
         await self.send_message(m)
 
-    async def request_headers(self, hash_start: types.UInt256, count: int = None) -> None:
+    async def request_headers(self, index_start: int, count: int = payloads.HeadersPayload.MAX_HEADERS_COUNT) -> None:
         """
-        Send a request for headers from `hash_start` to `hash_start`+`count`.
+        Send a request for headers from `index_start` to `index_start`+`count`.
 
         Not specifying a `count` results in requesting at most 2000 headers.
 
         Args:
-            hash_start:
+            index_start:
             count:
         """
         m = message.Message(msg_type=message.MessageType.GETHEADERS,
-                            payload=payloads.GetBlocksPayload(hash_start, count))
+                            payload=payloads.GetBlockByIndexPayload(index_start, count))
         await self.send_message(m)
 
     async def send_headers(self, headers: List[payloads.Header]) -> None:

--- a/tests/network/test_node.py
+++ b/tests/network/test_node.py
@@ -279,15 +279,15 @@ class NeoNodeTestCase(asynctest.TestCase):
     async def test_req_headers(self):
         n = node.NeoNode(object())
         n.send_message = asynctest.CoroutineMock()
-        hash_start = types.UInt256.from_string("65793a030c0dcd4fff4da8a6a6d5daa8b570750da4fdeea1bbc43bdf124aedc9")
+        index_start = 0
         count = 10
 
-        await n.request_headers(hash_start, count)
+        await n.request_headers(index_start, count)
         self.assertIsNotNone(n.send_message.call_args)
         m = n.send_message.call_args[0][0]  # type: message.Message
         self.assertEqual(message.MessageType.GETHEADERS, m.type)
-        self.assertIsInstance(m.payload, payloads.GetBlocksPayload)
-        self.assertEqual(hash_start, m.payload.hash_start)
+        self.assertIsInstance(m.payload, payloads.GetBlockByIndexPayload)
+        self.assertEqual(index_start, m.payload.index_start)
         self.assertEqual(count, m.payload.count)
 
     async def test_send_headers(self):


### PR DESCRIPTION
The payload used for requesting headers has changed. We no longer request by hash by but by index