### PR TITLE
fix wallet schema + version

### DIFF
--- a/neo3/wallet/wallet.py
+++ b/neo3/wallet/wallet.py
@@ -9,7 +9,7 @@ from neo3.wallet.scrypt_parameters import ScryptParameters
 schema = {
     "type": "object",
     "properties": {
-        "name": {"type": "string"},
+        "name": {"type": ["string", "null"]},
         "scrypt": {"$ref": "#/$defs/scrypt_parameters"},
         "accounts": {
             "type": "array",
@@ -21,22 +21,33 @@ schema = {
                   "additionalProperties": True
                   },
     },
-    "required": ["path", "name", "scrypt", "accounts", "extra"],
+    "required": ["name", "scrypt", "accounts", "extra"],
     "$defs": {
         "account": {
             "type": "object",
             "properties": {
                 "address": {"type": "string"},
-                "label": {"type": "string"},
-                "is_default": {"type": "boolean"},
+                "label": {"type": ["string", "null"]},
+                "isDefault": {"type": "boolean"},
                 "lock": {"type": "boolean"},
                 "key": {"type": "string"},
-                "contract": {"type": ""},
+                "contract": {
+                    "type": "object",
+                    "properties": {
+                        "script": {"type": "string"},
+                        "parameters": {
+                            "type": "array",
+                            "items": {"$ref": "#/$defs/contract_parameters"},
+                            "minItems": 0,
+                        },
+                    },
+                    "required": ["script", "parameters"]
+                },
                 "extra": {"type": ["object", "null"],
                           "properties": {},
                           "additionalProperties": True}
             },
-            "required": ["address", "label", "is_default", "lock", "key", "contract", "extra"]
+            "required": ["address", "label", "isDefault", "lock", "key", "contract", "extra"]
 
         },
         "scrypt_parameters": {
@@ -47,14 +58,22 @@ schema = {
                 "p": {"type": "integer"}
             },
             "required": ["n", "r", "p"]
+        },
+        "contract_parameters": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "type": {"type": "string"}
+            },
+            "required": ["name", "type"]
         }
-    }
+    },
 }
 
 
 class Wallet(IJson):
 
-    _wallet_version = '3.0'
+    _wallet_version = '1.0'
 
     def __init__(self,
                  name: Optional[str] = None,
@@ -218,11 +237,11 @@ class Wallet(IJson):
 
         Raises:
             KeyError: if the data supplied does not contain the necessary keys.
-            ValueError: if the 'version' property is under 3.0 or is not a valid string.
+            ValueError: if the 'version' property is under 1.0 or is not a valid string.
         """
         validate(json, schema=schema)
         try:
-            if float(json['version']) < 3.0:
+            if float(json['version']) < 1.0:
                 raise ValueError("Format error - invalid 'version'")
         except ValueError:
             raise ValueError("Format error - invalid 'version'")

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -24,7 +24,7 @@ class WalletCreationTestCase(unittest.TestCase):
         scrypt_parameters_default = wallet.ScryptParameters()
 
         self.assertEqual(wallet_file_name, test_wallet.name)
-        self.assertEqual('3.0', test_wallet.version)
+        self.assertEqual('1.0', test_wallet.version)
         self.assertEqual(scrypt_parameters_default.n, test_wallet.scrypt.n)
         self.assertEqual(scrypt_parameters_default.r, test_wallet.scrypt.r)
         self.assertEqual(scrypt_parameters_default.p, test_wallet.scrypt.p)
@@ -36,7 +36,7 @@ class WalletCreationTestCase(unittest.TestCase):
         scrypt_parameters_default = wallet.ScryptParameters()
 
         self.assertEqual('wallet.json', test_wallet.name)
-        self.assertEqual('3.0', test_wallet.version)
+        self.assertEqual('1.0', test_wallet.version)
         self.assertEqual(scrypt_parameters_default.n, test_wallet.scrypt.n)
         self.assertEqual(scrypt_parameters_default.r, test_wallet.scrypt.r)
         self.assertEqual(scrypt_parameters_default.p, test_wallet.scrypt.p)
@@ -95,7 +95,7 @@ class WalletCreationTestCase(unittest.TestCase):
 
         with Wallet(name=wallet_name) as test_wallet:
             self.assertEqual(wallet_name, test_wallet.name)
-            self.assertEqual('3.0', test_wallet.version)
+            self.assertEqual('1.0', test_wallet.version)
             self.assertEqual(scrypt_parameters_default.n, test_wallet.scrypt.n)
             self.assertEqual(scrypt_parameters_default.r, test_wallet.scrypt.r)
             self.assertEqual(scrypt_parameters_default.p, test_wallet.scrypt.p)


### PR DESCRIPTION
I was unable to import a JSON wallet exported by neo-cli via `Wallet.from_json()`. This fixes the version and schema errors

**Schema errors**
- `name` can be None
- `path` is not required per NEP6 standard
- `contract` validation scheme missing
- `is_default` must match the C# naming convention `isDefault`
- account `label` can be None

**wallet version**
Apparently the wallet version changed from `3.0` to `1.0`. This was missed because NEO thought it was nice to changed _CODE_ in a [PR](https://github.com/neo-project/neo/pull/2390) labelled "Add XML comments" 🤦  