### PR TITLE
Add extensible payload handling

### DIFF
--- a/neo3/network/message.py
+++ b/neo3/network/message.py
@@ -139,6 +139,8 @@ class Message(serialization.ISerializable):
                 return br.read_serializable(payloads.AddrPayload)
             elif msg_type == MessageType.TRANSACTION:
                 return br.read_serializable(payloads.Transaction)
+            elif msg_type == MessageType.EXTENSIBLE:
+                return br.read_serializable(payloads.ExtensiblePayload)
             else:
                 logger.debug(f"Unsupported payload {msg_type.name}")
 

--- a/neo3/network/node.py
+++ b/neo3/network/node.py
@@ -53,7 +53,8 @@ class NeoNode:
             message.MessageType.MERKLEBLOCK: self.handler_merkleblock,
             message.MessageType.PING: self.handler_ping,
             message.MessageType.PONG: self.handler_pong,
-            message.MessageType.TRANSACTION: self.handler_transaction
+            message.MessageType.TRANSACTION: self.handler_transaction,
+            message.MessageType.EXTENSIBLE: self.handler_extensible
         }
 
     # connection setup and control functions
@@ -383,6 +384,15 @@ class NeoNode:
     def handler_transaction(self, msg: message.Message) -> None:
         """
         Handler for a message with the TRANSACTION type.
+
+        Args:
+            msg:
+        """
+        pass
+
+    def handler_extensible(self, msg: message.Message) -> None:
+        """
+        Handler for a message with the EXTENSIBLE type.
 
         Args:
             msg:

--- a/neo3/network/payloads/extensible.py
+++ b/neo3/network/payloads/extensible.py
@@ -71,3 +71,7 @@ class ExtensiblePayload(payloads.IInventory):
 
     def get_script_hashes_for_verifying(self, snapshot: storage.Snapshot) -> List[types.UInt160]:
         return [self.sender]
+
+    @classmethod
+    def _serializable_init(cls):
+        return cls('', 0, 0, types.UInt160.zero(), b'', payloads.Witness(b'', b''))


### PR DESCRIPTION
While the `ExtensiblePayload` already existed, the P2P protocol didn't have a handler for it. This resulted in warnings in the network debug logs. 