### PR TITLE
NeoNode RPC Client

### DIFF
--- a/neo3/api/__init__.py
+++ b/neo3/api/__init__.py
@@ -1,0 +1,3 @@
+from .noderpc import NeoRpcClient, JsonRpcError
+
+__all__ = ['NeoRpcClient', 'JsonRpcError']

--- a/neo3/api/noderpc.py
+++ b/neo3/api/noderpc.py
@@ -210,7 +210,7 @@ class ExecutionResult:
                 key = ExecutionResult._parse_stack_item(stack_item['key'])
                 value = ExecutionResult._parse_stack_item(stack_item['value'])
                 map_.append((key, value))
-                return StackItem(type_, map_)
+            return StackItem(type_, map_)
         elif type_ == "Any":
             return StackItem(type_, None)
         else:

--- a/neo3/api/noderpc.py
+++ b/neo3/api/noderpc.py
@@ -328,14 +328,14 @@ class NeoRpcClient(RPCClient):
 
     async def get_best_block_hash(self) -> types.UInt256:
         """
-        Fetch the hash of the highest block in the chain
+        Fetch the hash of the highest block in the chain.
         """
         response = await self._post("getbestblockhash")
         return types.UInt256.from_string(response[2:])
 
     async def get_block(self, index_or_hash: Union[int, types.UInt256]) -> payloads.Block:
         """
-        Fetch the block by its index or block hash
+        Fetch the block by its index or block hash.
         """
         params: List[Union[int, str]] = []
         if isinstance(index_or_hash, types.UInt256):
@@ -347,20 +347,20 @@ class NeoRpcClient(RPCClient):
 
     async def get_block_count(self) -> int:
         """
-        Fetch the current height of the block chain
+        Fetch the current height of the block chain.
         """
         return await self._post("getblockcount")
 
     async def get_block_hash(self, index: int) -> types.UInt256:
         """
-        Fetch the block hash by the block's index
+        Fetch the block hash by the block's index.
         """
         response = await self._post("getblockhash", [index])
         return types.UInt256.from_string(response[2:])
 
     async def get_block_header(self, index_or_hash: Union[int, types.UInt256]) -> payloads.Header:
         """
-        Fetch the block header by its index or block hash
+        Fetch the block header by its index or block hash.
         """
         if isinstance(index_or_hash, types.UInt256):
             params = [f"0x{index_or_hash}"]
@@ -371,7 +371,7 @@ class NeoRpcClient(RPCClient):
 
     async def calculate_network_fee(self, transaction: Union[bytes, payloads.Transaction]) -> int:
         """
-        Obtain the cost of verifying the transaction and including it in a block (a.k.a network fee)
+        Obtain the cost of verifying the transaction and including it in a block (a.k.a network fee).
         """
         if isinstance(transaction, payloads.Transaction):
             transaction = transaction.to_array()
@@ -380,7 +380,7 @@ class NeoRpcClient(RPCClient):
 
     async def get_committee(self) -> List[cryptography.ECPoint]:
         """
-        Fetch the public keys of the current NEO committee
+        Fetch the public keys of the current NEO committee.
         """
         response = await self._post("getcommittee")
         keys = []
@@ -390,16 +390,16 @@ class NeoRpcClient(RPCClient):
 
     async def get_connection_count(self) -> int:
         """
-        Fetch the number of peers connected to the node
+        Fetch the number of peers connected to the node.
         """
         return await self._post("getconnectioncount")
 
     async def get_contract_state(self, contract_hash_or_name: Union[types.UInt160, str]) -> contracts.ContractState:
         """
-        Fetch smart contract state information
+        Fetch smart contract state information.
 
         Note:
-            Only native contracts can be queried by their name. Name is case-insensitive
+            Only native contracts can be queried by their name. Name is case-insensitive.
         """
         if isinstance(contract_hash_or_name, types.UInt160):
             params = [f"0x{contract_hash_or_name.to_array().hex()}"]
@@ -414,7 +414,7 @@ class NeoRpcClient(RPCClient):
 
     async def get_nep17_balances(self, address: str) -> Nep17BalancesResponse:
         """
-        Fetch the balance of all NEP17 assets for the specified address
+        Fetch the balance of all NEP17 assets for the specified address.
         """
         result = await self._post("getnep17balances", [address])
         return Nep17BalancesResponse.from_json(result)
@@ -425,7 +425,7 @@ class NeoRpcClient(RPCClient):
                                   end_time: Optional[datetime.datetime] = None,
                                   ) -> Nep17TransfersResponse:
         """
-        Obtain NEP17 transfers for a given address. Defaults to the last 7 days on the server side
+        Obtain NEP17 transfers for a given address. Defaults to the last 7 days on the server side.
 
         Args:
             address: account to get transfer for
@@ -460,7 +460,7 @@ class NeoRpcClient(RPCClient):
 
     async def get_raw_mempool(self) -> MempoolResponse:
         """
-        Return the transaction hashes currently in the memory pool waiting to be added to the next produced block
+        Return the transaction hashes currently in the memory pool waiting to be added to the next produced block.
         """
         result = await self._post("getrawmempool", [True])
         return MempoolResponse.from_json(result)
@@ -481,11 +481,11 @@ class NeoRpcClient(RPCClient):
 
     async def get_storage(self, script_hash: types.UInt160, key: bytes) -> bytes:
         """
-        Fetch a value from a smart contracts storage by its key
+        Fetch a value from a smart contracts storage by its key.
 
         Args:
             script_hash: contract script hash
-            key:
+            key: the storage key to fetch the data for
 
         Example:
             # fetch the fee per byte from the Policy native contract
@@ -522,7 +522,7 @@ class NeoRpcClient(RPCClient):
 
     async def get_unclaimed_gas(self, address: str) -> int:
         """
-        Fetch the amount of unclaimed gas for the given address
+        Fetch the amount of unclaimed gas for the given address.
 
         Args:
             address: a NEO address
@@ -579,7 +579,7 @@ class NeoRpcClient(RPCClient):
 
         Note:
             Calling smart contracts through this function does not alter the blockchain state.
-            To alter the blockchain state use `sendrawtransaction` instead.
+            To alter the blockchain state use the `send_transaction` method instead.
 
         Args:
             contract_hash: the hash of the smart contract to call
@@ -625,7 +625,7 @@ class NeoRpcClient(RPCClient):
             signers: additional signers (e.g. for checkwitness passing)
 
         Returns:
-            The results of executing the script in the VM.
+            The results of executing the script in the VM
         """
         signers = [] if signers is None else signers
         signers = list(map(lambda s: s.to_json(), signers))  # type: ignore
@@ -638,8 +638,11 @@ class NeoRpcClient(RPCClient):
         """
         Broadcast a transaction to the network.
 
+        Note:
+            uses the `sendrawtransaction` RPC method internally.
+
         Args:
-            tx: either a Transaction object or a serialized transaction.
+            tx: either a Transaction object or a serialized Transaction. Must be signed
 
         Returns:
             a transaction hash if successful.
@@ -654,7 +657,7 @@ class NeoRpcClient(RPCClient):
         Broadcast a transaction to the network.
 
         Args:
-            block: either a Block object or a serialized Block.
+            block: either a Block object or a serialized Block
 
         Returns:
             a block hash if successful.
@@ -666,7 +669,7 @@ class NeoRpcClient(RPCClient):
 
     async def validate_address(self, address: str) -> bool:
         """
-        Verify if the given address is for the network the node is running on
+        Verify if the given address is valid for the network the node is running on.
 
         Args:
             address: a NEO address

--- a/neo3/api/noderpc.py
+++ b/neo3/api/noderpc.py
@@ -1,0 +1,675 @@
+from __future__ import annotations
+import aiohttp
+import base64
+from dataclasses import dataclass
+from typing import List, Union, Optional, Dict, TypedDict, Any
+import datetime
+from neo3 import contracts
+from neo3.network import payloads
+from neo3.core import types, cryptography, IJson
+
+
+@dataclass
+class BlockValidator:
+    public_key: cryptography.ECPoint
+    votes: int
+    active: bool
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(public_key={self.public_key}, votes={self.votes}, acitive={self.active})"
+
+
+@dataclass
+class NextBlockValidatorsResponse:
+    validators: List[BlockValidator]
+
+    @classmethod
+    def from_json(cls, json: dict):
+        nvr = cls([])
+        for validator in json:
+            pk = cryptography.ECPoint.deserialize_from_bytes(bytes.fromhex(validator['publickey']))
+            votes = int(validator['votes'])
+            nvr.validators.append(BlockValidator(pk, votes, validator['active']))
+        return nvr
+
+
+@dataclass
+class VersionProtocol:
+    addressversion: int
+    network: int
+    validatorscount: int
+    msperblock: int
+    maxtraceableblocks: int
+    maxtransactionsperblock: int
+    maxvaliduntilblockincrement: int
+    memorypoolmaxtransactions: int
+    initialgasdistribution: int
+
+
+@dataclass
+class GetVersionResponse:
+    tcpport: int
+    wsport: int
+    nonce: int
+    useragent: str
+    protocol: VersionProtocol
+
+    @classmethod
+    def from_json(cls, json: dict):
+        json['protocol'] = VersionProtocol(**json['protocol'])
+        return cls(**json)
+
+
+@dataclass
+class Peer:
+    address: str
+    port: int
+
+
+@dataclass
+class GetPeersResponse:
+    connected: List[Peer]
+    bad: List[Peer]
+    unconnected: List[Peer]
+
+    @classmethod
+    def from_json(cls, json: dict):
+        c = cls([], [], [])
+        for p in json['connected']:
+            c.connected.append(Peer(**p))
+        for p in json['bad']:
+            c.bad.append(Peer(**p))
+        for p in json['unconnected']:
+            c.unconnected.append(Peer(**p))
+        return c
+
+
+@dataclass
+class Nep17Balance:
+    asset_hash: types.UInt160
+    amount: int
+    last_updated_block: int
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(asset_hash={self.asset_hash}, amount={self.amount}, " \
+               f"last_updated_block={self.last_updated_block})"
+
+
+@dataclass
+class Nep17BalancesResponse:
+    balances: List[Nep17Balance]
+    address: str
+
+    @classmethod
+    def from_json(cls, json: dict):
+        c = cls([], json['address'])
+        for b in json['balance']:
+            h = types.UInt160.from_string(b['assethash'][2:])
+            a = int(b['amount'])
+            c.balances.append(Nep17Balance(h, a, b['lastupdatedblock']))
+        return c
+
+
+@dataclass
+class Nep17Transfer:
+    time: datetime.datetime
+    asset_hash: types.UInt160
+    transfer_address: str
+    amount: int
+    block_index: int
+    transfer_notify_index: int
+    tx_hash: types.UInt256
+
+    @classmethod
+    def from_json(cls, json: dict):
+        time = datetime.datetime.fromtimestamp(json['timestamp'] / 1000, datetime.timezone.utc)
+        hash_ = types.UInt160.from_string(json['assethash'][2:])
+        transfer_addr = json['transferaddress']
+        amount = int(json['amount'])
+        tx_hash = types.UInt256.from_string(json['txhash'][2:])
+        return cls(time, hash_, transfer_addr, amount, json['blockindex'], json['transfernotifyindex'], tx_hash)
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(time={self.time}, asset_hash={self.asset_hash}, " \
+               f"transfer_address={self.transfer_address}, amount={self.amount}, block_index={self.block_index}, " \
+               f"transfer_notify_index={self.transfer_notify_index}, tx_hash={self.tx_hash})"
+
+
+@dataclass
+class Nep17TransfersResponse:
+    sent: List[Nep17Transfer]
+    received: List[Nep17Transfer]
+    address: str
+
+    @classmethod
+    def from_json(cls, json: dict):
+        c = cls([], [], json['address'])
+        for t in json['sent']:
+            c.sent.append(Nep17Transfer.from_json(t))
+        for t in json['received']:
+            c.received.append(Nep17Transfer.from_json(t))
+        return c
+
+
+@dataclass
+class MempoolResponse:
+    """
+    A verified transaction in the memory pool is a transaction which has had:
+    - basic structural validation (e.g. max tx size)
+    - signature validation
+    - state validation
+        - block validity expiration check
+        - available balance vs network and system fees
+        - etc
+    """
+    verified: List[types.UInt256]
+    unverified: List[types.UInt256]
+
+    @classmethod
+    def from_json(cls, json: dict):
+        c = cls([], [])
+        for tx in json['verified']:
+            c.verified.append(types.UInt256.from_string(tx[2:]))
+        for tx in json['unverified']:
+            c.unverified.append(types.UInt256.from_string(tx[2:]))
+        return c
+
+
+@dataclass
+class StackItem:
+    type: str
+    value: Any
+
+
+@dataclass
+class ExecutionResultResponse:
+    script: bytes
+    state: str
+    gas_consumed: int
+    exception: Optional[str]
+    stack: List[StackItem]
+
+    @staticmethod
+    def _parse_stack_item(item: TypedDict("item", {"type": str, "value": Any})) -> StackItem:
+        type_ = item['type']
+        if type_ in ("Array", "Struct"):
+            list_ = list(map(lambda element: ExecutionResultResponse._parse_stack_item(element), item['value']))
+            return StackItem(type_, list_)
+        elif type_ in ("Boolean", "Pointer"):
+            return StackItem(**item)
+        if type_ in ("Buffer", "ByteString"):
+            return StackItem(type_, base64.b64decode(item['value']))
+        elif type_ == "Integer":
+            return StackItem(type_, int(item['value']))
+        elif type_ == "Map":
+            map_ = []
+            for stack_item in item['value']:
+
+                key = ExecutionResultResponse._parse_stack_item(stack_item['key'])
+                value = ExecutionResultResponse._parse_stack_item(stack_item['value'])
+                map_.append((key, value))
+                return StackItem(type_, map_)
+        else:
+            raise ValueError(f"Unknown stack item type: {type_}")
+
+    @classmethod
+    def from_json(cls, json: dict):
+        script = base64.b64decode(json['script'])
+        gc = int(json['gasconsumed'])
+        stack = list(map(lambda item: ExecutionResultResponse._parse_stack_item(item), json['stack']))
+        return cls(script, json['state'], gc, json['exception'], stack)
+
+
+ContractParameter = Union[bool, int, str, bytes, bytearray, types.UInt160, types.UInt256, cryptography.ECPoint,
+                          List['ContractParameter'], Dict['ContractParameter', 'ContractParameter']]
+
+
+class _ContractParameter(IJson):
+    def __init__(self, obj: ContractParameter):
+        self.value: ContractParameter = ''  # just to help mypy
+        if isinstance(obj, bool):
+            self.type = contracts.ContractParameterType.BOOLEAN
+            self.value = obj
+        elif isinstance(obj, int):
+            self.type = contracts.ContractParameterType.INTEGER
+            self.value = str(obj)
+        elif isinstance(obj, str):
+            self.type = contracts.ContractParameterType.STRING
+            self.value = obj
+        elif isinstance(obj, (bytes, bytearray)):
+            self.type = contracts.ContractParameterType.BYTEARRAY
+            self.value = base64.b64encode(obj).decode()
+        elif isinstance(obj, types.UInt160):
+            self.type = contracts.ContractParameterType.HASH160
+            self.value = f"0x{obj}"
+        elif isinstance(obj, types.UInt256):
+            self.type = contracts.ContractParameterType.HASH256
+            self.value = f"0x{obj}"
+        elif isinstance(obj, cryptography.ECPoint):
+            self.type = contracts.ContractParameterType.PUBLICKEY
+            self.value = obj.to_array().hex()
+        elif isinstance(obj, list):
+            self.type = contracts.ContractParameterType.ARRAY
+            self.value = list(map(lambda element: _ContractParameter(element), obj))
+        elif isinstance(obj, dict):
+            self.type = contracts.ContractParameterType.MAP
+            pairs = []
+            for k, v in obj.items():
+                pairs.append({"key": _ContractParameter(k), "value": _ContractParameter(v)})
+            self.value = pairs
+        else:
+            raise ValueError(f"Unsupported type {type(obj)}")
+
+    @classmethod
+    def from_json(cls, json: dict):
+        """ Not supported """
+        raise NotImplementedError
+
+    def to_json(self) -> dict:
+        return {"type": self.type.PascalCase(), "value": self.value}
+
+
+class RPCClient:
+    def __init__(self, url: str, timeout: float = 3.0):
+        """
+        Args:
+            url: host + port
+            timeout: total time in seconds a request may take
+        """
+        self.url = url
+        self.timeout = timeout
+        self.session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=self.timeout))
+
+    async def _post(self, json: dict):
+        """
+        Create a POST request with JSON to `self.url` with `self.timeout`
+
+        Raises:
+            asyncio.exceptions.TimeoutError
+        """
+        async with self.session.post(self.url, json=json) as request:
+            return await request.json()
+
+    async def close(self):
+        """
+        Close the client session
+        """
+        await self.session.close()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        if not self.session.closed:
+            await self.session.close()
+
+
+class JsonRpcError(Exception):
+    def __init__(self, code: int, message: str, data: str = None):
+        self.code = code
+        self.message = message
+        self.data = "" if data is None else data
+
+    def __str__(self):
+        return f"({self.code}) {self.message}"
+
+
+class NeoRpcClient(RPCClient):
+    def __init__(self, host: str):
+        super(NeoRpcClient, self).__init__(host)
+
+    async def _post(self, method: str, params: List = None, id: int = 0, jsonrpc_version: str = "2.0"):
+        params = params if params else []
+        json = {'jsonrpc': jsonrpc_version, 'id': id, "method": method, "params": params}
+        response = await super(NeoRpcClient, self)._post(json)
+        if "error" in response:
+            raise JsonRpcError(**response['error'])
+        return response['result']
+
+    async def get_best_block_hash(self) -> types.UInt256:
+        """
+        Fetch the hash of the highest block in the chain
+        """
+        response = await self._post("getbestblockhash")
+        return types.UInt256.from_string(response[2:])
+
+    async def get_block(self, index_or_hash: Union[int, types.UInt256]) -> payloads.Block:
+        """
+        Fetch the block by its index or block hash
+        """
+        params: List[Union[int, str]] = []
+        if isinstance(index_or_hash, types.UInt256):
+            params.append(f"0x{index_or_hash}")
+        else:
+            params.append(index_or_hash)
+        response = await self._post("getblock", params)
+        return payloads.Block.deserialize_from_bytes(base64.b64decode(response))
+
+    async def get_block_count(self) -> int:
+        """
+        Fetch the current height of the block chain
+        """
+        return await self._post("getblockcount")
+
+    async def get_block_hash(self, index: int) -> types.UInt256:
+        """
+        Fetch the block hash by the block's index
+        """
+        response = await self._post("getblockhash", [index])
+        return types.UInt256.from_string(response[2:])
+
+    async def get_block_header(self, index_or_hash: Union[int, types.UInt256]) -> payloads.Header:
+        """
+        Fetch the block header by its index or block hash
+        """
+        if isinstance(index_or_hash, types.UInt256):
+            params = [f"0x{index_or_hash}"]
+        else:
+            params = [str(index_or_hash)]
+        response = await self._post("getblockheader", params)
+        return payloads.Header.deserialize_from_bytes(base64.b64decode(response))
+
+    async def calculate_network_fee(self, transaction: Union[bytes, payloads.Transaction]) -> int:
+        """
+        Obtain the cost of verifying the transaction and including it in a block (a.k.a network fee)
+        """
+        if isinstance(transaction, payloads.Transaction):
+            transaction = transaction.to_array()
+        params = [base64.b64encode(transaction).decode()]
+        return await self._post("calculatenetworkfee", params)
+
+    async def get_committee(self) -> List[cryptography.ECPoint]:
+        """
+        Fetch the public keys of the current NEO committee
+        """
+        response = await self._post("getcommittee")
+        keys = []
+        for pk in response:
+            keys.append(cryptography.ECPoint.deserialize_from_bytes(bytes.fromhex(pk)))
+        return keys
+
+    async def get_connection_count(self) -> int:
+        """
+        Fetch the number of peers connected to the node
+        """
+        return await self._post("getconnectioncount")
+
+    async def get_contract_state(self, contract_hash_or_name: Union[types.UInt160, str]) -> contracts.ContractState:
+        """
+        Fetch smart contract state information
+
+        Note:
+            Only native contracts can be queried by their name. Name is case-insensitive
+        """
+        if isinstance(contract_hash_or_name, types.UInt160):
+            params = [f"0x{contract_hash_or_name.to_array().hex()}"]
+        else:
+            params = [contract_hash_or_name]
+        result = await self._post("getcontractstate", params)
+
+        h = types.UInt160.from_string(result['hash'][2:])
+        nef = contracts.NEF.from_json(result['nef'])
+        manifest = contracts.ContractManifest.from_json(result['manifest'])
+        return contracts.ContractState(result['id'], nef, manifest, result['updatecounter'], h)
+
+    async def get_nep17_balances(self, address: str) -> Nep17BalancesResponse:
+        """
+        Fetch the balance of all NEP17 assets for the specified address
+        """
+        result = await self._post("getnep17balances", [address])
+        return Nep17BalancesResponse.from_json(result)
+
+    async def get_nep17_transfers(self,
+                                  address: str,
+                                  start_time: Optional[datetime.datetime] = None,
+                                  end_time: Optional[datetime.datetime] = None,
+                                  ) -> Nep17TransfersResponse:
+        """
+        Obtain NEP17 transfers for a given address. Defaults to the last 7 days on the server side
+
+        Args:
+            address: account to get transfer for
+            start_time: if given the start of the requested range. Must be in UTC and time aware not naïve
+            end_time: if given the end of the requested range
+
+        Example:
+            # Fetch transfers of the last 14 days
+            start = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=14)
+            await get_nep17_transfers(<your address>, start)
+        """
+        params = [address]
+        if start_time is not None:
+            if start_time.tzinfo is None:
+                raise ValueError("start_time is a naïve datetime object which can cause incorrect results. Make it "
+                                 "time aware by adding tzinfo. For more information see: "
+                                 "https://docs.python.org/3/library/datetime.html#datetime.datetime.tzinfo")
+            # C# server side expects timestamp in milliseconds instead of seconds
+            t = int(start_time.timestamp() * 1000)
+            params.append(str(t))
+
+        if end_time is not None:
+            if end_time.tzinfo is None:
+                raise ValueError("end_time is a naïve object which can cause incorrect results. Make it time aware by "
+                                 "adding tzinfo. For more information see: "
+                                 "https://docs.python.org/3/library/datetime.html#datetime.datetime.tzinfo")
+            t = int(end_time.timestamp() * 1000)
+            params.append(str(t))
+
+        result = await self._post("getnep17transfers", params)
+        return Nep17TransfersResponse.from_json(result)
+
+    async def get_raw_mempool(self) -> MempoolResponse:
+        """
+        Return the transaction hashes currently in the memory pool waiting to be added to the next produced block
+        """
+        result = await self._post("getrawmempool", [True])
+        return MempoolResponse.from_json(result)
+
+    async def get_next_blockvalidators(self) -> NextBlockValidatorsResponse:
+        """
+        Fetch the list of next block validators.
+        """
+        result = await self._post("getnextblockvalidators")
+        return NextBlockValidatorsResponse.from_json(result)
+
+    async def get_peers(self) -> GetPeersResponse:
+        """
+        Fetch peer information
+        """
+        result = await self._post("getpeers")
+        return GetPeersResponse.from_json(result)
+
+    async def get_storage(self, script_hash: types.UInt160, key: bytes) -> bytes:
+        """
+        Fetch a value from a smart contracts storage by its key
+
+        Args:
+            script_hash: contract script hash
+            key:
+
+        Example:
+            # fetch the fee per byte from the Policy native contract
+            key_fee_per_byte = b'\x0a'
+            await client.get_storage(contracts.PolicyContract().hash, key_fee_per_byte)
+        """
+        hash_ = f"0x{script_hash}"
+        key_encoded = base64.b64encode(key).decode()
+        result = await self._post("getstorage", params=[hash_, key_encoded])
+        return base64.b64decode(result)
+
+    async def get_transaction(self, tx_hash: Union[types.UInt256, str]) -> payloads.Transaction:
+        """
+        Fetch a transaction by its hash.
+
+        Args:
+            tx_hash: as string without "0x" prefix!
+        """
+        if isinstance(tx_hash, str):
+            tx_hash = types.UInt256.from_string(tx_hash)
+        result = await self._post("getrawtransaction", [f"0x{tx_hash}"])
+        return payloads.Transaction.deserialize_from_bytes(base64.b64decode(result))
+
+    async def get_transaction_height(self, tx_hash: Union[types.UInt256, str]) -> int:
+        """
+        Fetch the height of the block the transaction is included in.
+
+        Args:
+            tx_hash: as string without "0x" prefix!
+        """
+        if isinstance(tx_hash, str):
+            tx_hash = types.UInt256.from_string(tx_hash)
+        return await self._post("gettransactionheight", [f"0x{tx_hash}"])
+
+    async def get_unclaimed_gas(self, address: str) -> int:
+        """
+        Fetch the amount of unclaimed gas for the given address
+
+        Args:
+            address: a NEO address
+        """
+        result = await self._post("getunclaimedgas", [address])
+        return int(result['unclaimed'])
+
+    async def get_version(self) -> GetVersionResponse:
+        """
+        Fetch the node client version, network protocol properties and network ports.
+        """
+        return GetVersionResponse.from_json(await self._post("getversion"))
+
+    async def invoke_contract_verify(self,
+                                     contract_hash: Union[types.UInt160, str],
+                                     function_params: Optional[List[ContractParameter]] = None,
+                                     signers: Optional[List[payloads.Signer]] = None
+                                     ) -> ExecutionResultResponse:
+        """
+        Invoke the `verify` method on the contract.
+
+        Note:
+            Calling smart contracts through this function does not alter the blockchain state.
+            The smart contract will be called using the Verification trigger (unlike the `invoke_function` method
+            which uses the Application trigger).
+
+        Args:
+            contract_hash: the hash of the smart contract to call
+            function_params: the arguments required by the smart contract function
+            signers: additional signers (e.g. for checkwitness passing)
+        """
+        if isinstance(contract_hash, str):
+            contract_hash = types.UInt160.from_string(contract_hash)
+        contract_hash = f"0x{contract_hash}"
+
+        function_params = [] if function_params is None else function_params
+        function_params = list(map(lambda fp: _ContractParameter(fp).to_json(), function_params))
+
+        signers = [] if signers is None else signers
+        signers = list(map(lambda s: s.to_json(), signers))  # type: ignore
+
+        params = [contract_hash, function_params, signers]
+        result = await self._post("invokecontractverify", params)
+        return ExecutionResultResponse.from_json(result)
+
+    async def invoke_function(self,
+                              contract_hash: Union[types.UInt160, str],
+                              name: str,
+                              function_params: Optional[List[ContractParameter]] = None,
+                              signers: Optional[List[payloads.Signer]] = None
+                              ) -> ExecutionResultResponse:
+        """
+        Invoke a smart contract function.
+
+        Note:
+            Calling smart contracts through this function does not alter the blockchain state.
+            To alter the blockchain state use `sendrawtransaction` instead.
+
+        Args:
+            contract_hash: the hash of the smart contract to call
+            name: the name of the function to call on the smart contract
+            function_params: the arguments required by the smart contract function
+            signers: additional signers (e.g. for checkwitness passing)
+
+        Example:
+            # check if an account is blocked using the Policy native contract
+            policy_contract = "cc5e4edd9f5f8dba8bb65734541df7a1c081c67b"
+            account_to_check = types.UInt160.from_string("86df72a6b4ab5335d506294f9ce993722253b6e2")
+            signer_account = types.UInt160.from_string("f621168b1fce3a89c33a5f6bcf7e774b4657031c")
+            signer = payloads.Signer(signer_account, payloads.WitnessScope.CALLED_BY_ENTRY)
+            await client.invoke_function(contract_hash=policy_contract, name="isBlocked",
+                                         function_params=[account_to_check], signers=[signer])
+        """
+        if isinstance(contract_hash, str):
+            contract_hash = types.UInt160.from_string(contract_hash)
+        contract_hash = f"0x{contract_hash}"
+
+        function_params = [] if function_params is None else function_params
+        function_params = list(map(lambda fp: _ContractParameter(fp).to_json(), function_params))
+
+        signers = [] if signers is None else signers
+        signers = list(map(lambda s: s.to_json(), signers))  # type: ignore
+
+        params = [contract_hash, name, function_params, signers]
+        result = await self._post("invokefunction", params)
+        return ExecutionResultResponse.from_json(result)
+
+    async def invoke_script(self,
+                            script: bytes,
+                            signers: Optional[List[payloads.Signer]] = None
+                            ) -> ExecutionResultResponse:
+        """
+        Executes a script in the virtual machine.
+
+        Note:
+            Executing VM scripts through this function does not alter the blockchain state.
+
+        Args:
+            script: an array of VM opcodes
+            signers: additional signers (e.g. for checkwitness passing)
+
+        Returns:
+            The results of executing the script in the VM.
+        """
+        signers = [] if signers is None else signers
+        signers = list(map(lambda s: s.to_json(), signers))  # type: ignore
+
+        params = [base64.b64encode(script).decode(), signers]
+        result = await self._post("invokescript", params)
+        return ExecutionResultResponse.from_json(result)
+
+    async def send_transaction(self, tx: Union[payloads.Transaction, bytes]) -> types.UInt256:
+        """
+        Broadcast a transaction to the network.
+
+        Args:
+            tx: either a Transaction object or a serialized transaction.
+
+        Returns:
+            a transaction hash if successful.
+        """
+        if isinstance(tx, payloads.Transaction):
+            tx = tx.to_array()
+        result = await self._post("sendrawtransaction", [base64.b64encode(tx).decode()])
+        return types.UInt256.from_string(result['hash'][2:])
+
+    async def send_block(self, block: Union[payloads.Block, bytes]) -> types.UInt256:
+        """
+        Broadcast a transaction to the network.
+
+        Args:
+            block: either a Block object or a serialized Block.
+
+        Returns:
+            a block hash if successful.
+        """
+        if isinstance(block, payloads.Block):
+            block = block.to_array()
+        result = await self._post("submitblock", [base64.b64encode(block).decode()])
+        return types.UInt256.from_string(result['hash'][2:])
+
+    async def validate_address(self, address: str) -> bool:
+        """
+        Verify if the given address is for the network the node is running on
+
+        Args:
+            address: a NEO address
+        """
+        result = await self._post("validateaddress", [address])
+        return result['isvalid']

--- a/neo3/contracts/callflags.py
+++ b/neo3/contracts/callflags.py
@@ -13,3 +13,24 @@ class CallFlags(IntFlag):
     STATES = READ_STATES | WRITE_STATES
     READ_ONLY = READ_STATES | ALLOW_CALL
     ALL = STATES | ALLOW_CALL | ALLOW_NOTIFY
+
+    @classmethod
+    def from_csharp_name(cls, input: str):
+        if input == "None":
+            return CallFlags.NONE
+        elif input == "ReadStates":
+            return CallFlags.READ_STATES
+        elif input == "WriteStates":
+            return CallFlags.WRITE_STATES
+        elif input == "AllowCall":
+            return CallFlags.ALLOW_CALL
+        elif input == "AllowNotify":
+            return CallFlags.ALLOW_NOTIFY
+        elif input == "States":
+            return CallFlags.STATES
+        elif input == "ReadOnly":
+            return CallFlags.READ_ONLY
+        elif input == "All":
+            return CallFlags.ALL
+        else:
+            raise ValueError(f"{input} is not a valid member of {cls.__name__}")

--- a/neo3/contracts/nef.py
+++ b/neo3/contracts/nef.py
@@ -177,7 +177,7 @@ class MethodToken(serialization.ISerializable, IJson):
     def from_json(cls, json: dict):
         h = types.UInt160.from_string(json['hash'][2:])
         m = json['method']
-        pc = json['parameterscount']
+        pc = json['paramcount']
         rv = json['hasreturnvalue']
         cf = contracts.CallFlags.from_csharp_name(json['callflags'])
         return cls(h, m, pc, rv, cf)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 aiodns==3.0.0
 aiohttp==3.7.4.post0
 asynctest==0.13.0
+aioresponses==0.7.2
 base58==2.1.0
 bitarray==2.3.4
 coverage>=6.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiodns==3.0.0
+aiohttp==3.7.4.post0
 asynctest==0.13.0
 base58==2.1.0
 bitarray==2.3.4

--- a/tests/api/test_noderpc.py
+++ b/tests/api/test_noderpc.py
@@ -335,6 +335,60 @@ class TestNeoRpcClient(unittest.IsolatedAsyncioTestCase):
                 {
                     "type": "Boolean",
                     "value": True
+                },
+                {
+                    "type": "Map",
+                    "value": [
+                        {
+                            "key": {
+                                "type": "ByteString",
+                                "value": "bmFtZQ=="
+                            },
+                            "value": {
+                                "type": "ByteString",
+                                "value": "TyAjOTU3IEludGVyb3BlcmFiaWxpdHk="
+                            }
+                        },
+                        {
+                            "key": {
+                                "type": "ByteString",
+                                "value": "b3duZXI="
+                            },
+                            "value": {
+                                "type": "ByteString",
+                                "value": "/d5rikUuvYmC6NRzIP3I3ETAoOw="
+                            }
+                        },
+                        {
+                            "key": {
+                                "type": "ByteString",
+                                "value": "bnVtYmVy"
+                            },
+                            "value": {
+                                "type": "Integer",
+                                "value": "957"
+                            }
+                        },
+                        {
+                            "key": {
+                                "type": "ByteString",
+                                "value": "aW1hZ2U="
+                            },
+                            "value": {
+                                "type": "ByteString",
+                                "value": "aHR0cHM6Ly9uZW8ub3JnL0ludGVyb3BlcmFiaWxpdHkucG5n"
+                            }
+                        },
+                        {
+                            "key": {
+                                "type": "ByteString",
+                                "value": "dmlkZW8="
+                            },
+                            "value": {
+                                "type": "Any"
+                            }
+                        }
+                    ]
                 }
             ]
         }
@@ -343,8 +397,10 @@ class TestNeoRpcClient(unittest.IsolatedAsyncioTestCase):
 
         contract_hash = "92f5c79b88560584a900cfec15b0e00dc4d58b59"
         response = await self.client.invoke_function(contract_hash, "dummy_func")
-        self.assertEqual(1, len(response.stack))
+        self.assertEqual(2, len(response.stack))
         self.assertTrue(response.stack[0].value)
+        self.assertEqual("Map", response.stack[1].type)
+        self.assertEqual(5, len(response.stack[1].value))
 
     async def test_invoke_script(self):
         captured = {

--- a/tests/api/test_noderpc.py
+++ b/tests/api/test_noderpc.py
@@ -1,0 +1,413 @@
+import unittest
+import base64
+from typing import Optional, Any
+from aioresponses import aioresponses
+from neo3 import api
+from neo3.network import payloads
+from neo3.core import types, cryptography
+
+JSON = Any
+
+
+class TestNeoRpcClient(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.client = api.NeoRpcClient('localhost')
+        self.helper = aioresponses()
+        self.helper.start()
+
+    async def asyncTearDown(self) -> None:
+        self.helper.stop()
+        await self.client.close()
+
+    def mock_response(self, payload: Optional[JSON] = None, exc: Optional[Exception] = None):
+        """
+        Either payload or exc should be provided
+        """
+        if payload is not None and exc is not None:
+            raise ValueError("Arguments are mutual exclusive")
+
+        if payload is not None:
+            json = {'jsonrpc': '2.0', 'id': 1, "result": payload}
+            self.helper.post('localhost', payload=json)
+        else:
+            self.helper.post('localhost', exception=exc)
+
+    async def test_calculate_network_fee(self):
+        self.mock_response({"networkfee": "123"})
+        response = await self.client.calculate_network_fee(payloads.Transaction._serializable_init())
+        self.assertEqual(123, response)
+
+    async def test_get_application_log(self):
+        captured = {
+            "txid": "0x7da6ae7ff9d0b7af3d32f3a2feb2aa96c2a27ef8b651f9a132cfaad6ef20724c",
+            "executions": [
+                {
+                    "trigger": "Application",
+                    "vmstate": "HALT",
+                    "exception": None,
+                    "gasconsumed": "9999540",
+                    "stack": [],
+                    "notifications": [
+                        {
+                            "contract": "0x70e2301955bf1e74cbb31d18c2f96972abadb328",
+                            "eventname": "Transfer",
+                            "state": {
+                                "type": "Array",
+                                "value": [
+                                    {
+                                        "type": "ByteString",
+                                        "value": "4rZTInKT6ZxPKQbVNVOrtKZy34Y="
+                                    },
+                                    {
+                                        "type": "ByteString",
+                                        "value": "+on7LBTfD1nd3wT25WUX8rNKrus="
+                                    },
+                                    {
+                                        "type": "Integer",
+                                        "value": "10000000000"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+        self.mock_response(captured)
+        tx_hash = types.UInt256.from_string("0x7da6ae7ff9d0b7af3d32f3a2feb2aa96c2a27ef8b651f9a132cfaad6ef20724c"[2:])
+        response = await self.client.get_application_log(tx_hash)
+        self.assertEqual(1, len(response.executions))
+        self.assertEqual(0, len(response.executions[0].stack))
+        self.assertEqual("HALT", response.executions[0].state)
+        self.assertEqual(1, len(response.executions[0].notifications))
+        self.assertEqual("Transfer", response.executions[0].notifications[0].event_name)
+
+    async def test_get_best_block_hash(self):
+        hash_ = "0xbee7a65279d6b31cc45445a7579d4c4a4e52d1edc13cc7ec7a41f7b1affdf0ab"
+        self.mock_response(hash_)
+        response = await self.client.get_best_block_hash()
+        self.assertEqual(types.UInt256.from_string(hash_[2:]), response)
+
+    async def test_get_block(self):
+        block = payloads.Block._serializable_init()
+        self.mock_response(base64.b64encode(block.to_array()).decode())
+        response_block = await self.client.get_block(1)
+        self.assertEqual(block, response_block)
+
+    async def test_get_block_count(self):
+        count = 1
+        self.mock_response(count)
+        response = await self.client.get_block_count()
+        self.assertEqual(count, response)
+
+    async def test_get_block_hash(self):
+        hash_ = "0xbee7a65279d6b31cc45445a7579d4c4a4e52d1edc13cc7ec7a41f7b1affdf0ab"
+        self.mock_response(hash_)
+        response = await self.client.get_block_hash(1)
+        self.assertEqual(types.UInt256.from_string(hash_[2:]), response)
+
+    async def test_get_block_header(self):
+        block = payloads.Block._serializable_init()
+        self.mock_response(base64.b64encode(block.to_array()).decode())
+        response_header = await self.client.get_block_header(1)
+        self.assertEqual(block.header, response_header)
+
+    async def test_get_committee(self):
+        points = [
+            "02237309a0633ff930d51856db01d17c829a5b2e5cc2638e9c03b4cfa8e9c9f971",
+            "022f1beae94cf0d266d7d26691b431958c8d13768103ab20aed817b57568da293f",
+            "0239a37436652f41b3b802ca44cbcb7d65d3aa0b88c9a0380243bdbe1aaa5cb35b"
+        ]
+        self.mock_response(points)
+        expected = list(map(lambda p: cryptography.ECPoint.deserialize_from_bytes(bytes.fromhex(p)), points))
+        committee = await self.client.get_committee()
+        self.assertEqual(expected, committee)
+
+    async def test_get_connection_count(self):
+        count = 1
+        self.mock_response(count)
+        response = await self.client.get_connection_count()
+        self.assertEqual(count, response)
+
+    async def test_get_contract_state(self):
+        contract_hash_str = "0xb776afb6ad0c11565e70f8ee1dd898da43e51be1"
+        contract_hash = types.UInt160.from_string(contract_hash_str[2:])
+        captured = {'id': 1, 'updatecounter': 0, 'hash': contract_hash_str, 'nef': {'magic': 860243278, 'compiler': 'Neo.Compiler.CSharp 3.0.0', 'source': '', 'tokens': [{'hash': '0xfffdc93764dbaddd97c48f252a53ea4643faa3fd', 'method': 'update', 'paramcount': 3, 'hasreturnvalue': False, 'callflags': 'All'}, {'hash': '0xef4073a0f2b305a38ec4050e4d3d28bc40ea63f5', 'method': 'getCandidates', 'paramcount': 0, 'hasreturnvalue': True, 'callflags': 'All'}, {'hash': '0x726cb6e0cd8628a1350a611384688911ab75f51b', 'method': 'ripemd160', 'paramcount': 1, 'hasreturnvalue': True, 'callflags': 'All'}, {'hash': '0x726cb6e0cd8628a1350a611384688911ab75f51b', 'method': 'sha256', 'paramcount': 1, 'hasreturnvalue': True, 'callflags': 'All'}, {'hash': '0xacce6fd80d44e1796aa0c2c625e9e4e0ce39efc0', 'method': 'serialize', 'paramcount': 1, 'hasreturnvalue': True, 'callflags': 'All'}, {'hash': '0xacce6fd80d44e1796aa0c2c625e9e4e0ce39efc0', 'method': 'deserialize', 'paramcount': 1, 'hasreturnvalue': True, 'callflags': 'All'}], 'script': 'NA5B+CfsjEBB+CfsjEBXAQAMCnN1cGVyQWRtaW40IHBoStgkA8oAFJcmEGhK2CQJSsoAFCgDOiIDWCICQFcAAXhBm/ZnzkGSXegxIgJAQZJd6DFAQZv2Z85AykBXAAEMCUZvcmJpZGRlbjSkQfgn7Iw0F3gMCnN1cGVyQWRtaW40EhHbICICQFcAAniqJgR5OkBXAAJ5eEGb9mfOQeY/GIRAQeY/GIRAVwADNVX///+qJhYMEU5vIGF1dGhvcml6YXRpb24uOnp5eDcAAEA3AABAVwABWXjbMItAi0DbMEBXCAoMCUZvcmJpZGRlbnhB+CfsjDSUNwEAcBDbIHFoSnLKcxB0Ih9qbM7BRXV2bTRhdwd4bweXJgoR2yBKcUUiCWycdGxrMOEMF1NlbmRlciBpcyBub3QgQ2FuZGlkYXRlaTVG////fwl/CH8Hfn18e3p5eBrASjRLcmo3BAB4NXP///80QhHbICICQDcBAEBXAgFaeNswi1uLcGjbKDcDADcCAHFpStgkCUrKABQoAzoiAkDbMEA3AgBANwMAQNsoQFcAAUBXAAJ5eEGb9mfOQeY/GIRAQeY/GIRANwQAQFcBAXg1Dv///zQXcGhK2CQDyhC3JghoNwUAIgULIgJAVwABeEGb9mfOQZJd6DEiAkBBkl3oMUA3BQBAVwMAWTQocBDEAHFoQZwI7ZwmF2hB81S/HXJqEc4LmCYHaWoRzs8i5WkiAkBXAAEaeEGb9mfOQd8wuJoiAkBB3zC4mkBBnAjtnEBB81S/HUDPQFcCAQwJRm9yYmlkZGVueEH4J+yMJgcR2yAiBzWY/f//NRv+//94NV/+//9weDVY/v//NWH///9xaUrYJAPKELcmCmg0DRHbICIHENsgIgJAVwABeNsoQZv2Z85BL1jF7UBBL1jF7UDPQFYEDBTARUMMYSJWDL3Fhow6TOAvAt28wWAMAgwh2zBiDAVBVuezJ9swYwwBd9swYUA=', 'checksum': 3038242458}, 'manifest': {'name': 'CommitteeInfoContract', 'groups': [], 'features': {}, 'supportedstandards': [], 'abi': {'methods': [{'name': 'verify', 'parameters': [], 'returntype': 'Boolean', 'offset': 0, 'safe': False}, {'name': 'getAdmin', 'parameters': [], 'returntype': 'Hash160', 'offset': 14, 'safe': False}, {'name': 'setAdmin', 'parameters': [{'name': 'admin', 'type': 'Hash160'}], 'returntype': 'Boolean', 'offset': 92, 'safe': False}, {'name': 'update', 'parameters': [{'name': 'nefFile', 'type': 'ByteArray'}, {'name': 'manifest', 'type': 'String'}, {'name': 'data', 'type': 'Any'}], 'returntype': 'Void', 'offset': 168, 'safe': False}, {'name': 'setInfo', 'parameters': [{'name': 'sender', 'type': 'Hash160'}, {'name': 'name', 'type': 'String'}, {'name': 'location', 'type': 'String'}, {'name': 'website', 'type': 'String'}, {'name': 'email', 'type': 'String'}, {'name': 'github', 'type': 'String'}, {'name': 'telegram', 'type': 'String'}, {'name': 'twitter', 'type': 'String'}, {'name': 'description', 'type': 'String'}, {'name': 'logo', 'type': 'String'}], 'returntype': 'Boolean', 'offset': 224, 'safe': False}, {'name': 'getInfo', 'parameters': [{'name': 'candidate', 'type': 'Hash160'}], 'returntype': 'Any', 'offset': 448, 'safe': False}, {'name': 'getAllInfo', 'parameters': [], 'returntype': 'Array', 'offset': 507, 'safe': False}, {'name': 'deleteInfo', 'parameters': [{'name': 'candidate', 'type': 'Hash160'}], 'returntype': 'Boolean', 'offset': 589, 'safe': False}, {'name': '_initialize', 'parameters': [], 'returntype': 'Void', 'offset': 694, 'safe': False}], 'events': []}, 'permissions': [{'contract': '0x726cb6e0cd8628a1350a611384688911ab75f51b', 'methods': ['ripemd160', 'sha256']}, {'contract': '0xacce6fd80d44e1796aa0c2c625e9e4e0ce39efc0', 'methods': ['deserialize', 'serialize']}, {'contract': '0xef4073a0f2b305a38ec4050e4d3d28bc40ea63f5', 'methods': ['getCandidates']}, {'contract': '0xfffdc93764dbaddd97c48f252a53ea4643faa3fd', 'methods': ['update']}], 'trusts': [], 'extra': {'Author': 'NEO', 'Email': 'developer@neo.org', 'Description': 'This is a Neo3 Contract'}}}
+        self.mock_response(captured)
+
+        response_state = await self.client.get_contract_state(contract_hash)
+        self.assertEqual(contract_hash, response_state.hash)
+        self.assertEqual("CommitteeInfoContract", response_state.manifest.name)
+
+    async def test_get_nep17_balances(self):
+        captured = {
+            "balance": [
+                {
+                    "assethash": "0x70e2301955bf1e74cbb31d18c2f96972abadb328",
+                    "amount": "3000000100000000",
+                    "lastupdatedblock": 2
+                },
+                {
+                    "assethash": "0xf61eebf573ea36593fd43aa150c055ad7906ab83",
+                    "amount": "99999900",
+                    "lastupdatedblock": 2
+                }
+            ],
+            "address": "NgaiKFjurmNmiRzDRQGs44yzByXuSkdGPF"
+        }
+        self.mock_response(captured)
+
+        response = await self.client.get_nep17_balances("bogus_addr")
+        self.assertEqual(2, len(response.balances))
+        self.assertEqual(99999900, response.balances[1].amount)
+
+    async def test_get_nep17_transfers(self):
+        captured = {
+            "sent": [],
+            "received": [
+                {
+                    "timestamp": 1612690497725,
+                    "assethash": "0xf61eebf573ea36593fd43aa150c055ad7906ab83",
+                    "transferaddress": "NgaiKFjurmNmiRzDRQGs44yzByXuSkdGPF",
+                    "amount": "100",
+                    "blockindex": 2,
+                    "transfernotifyindex": 1,
+                    "txhash": "0x5f957960a782514d6587c445288ee1cca7d6b0f952edc204f14d9be83b8152ff"
+                },
+                {
+                    "timestamp": 1612690513541,
+                    "assethash": "0x70e2301955bf1e74cbb31d18c2f96972abadb328",
+                    "transferaddress": "NgaiKFjurmNmiRzDRQGs44yzByXuSkdGPF",
+                    "amount": "10000000000",
+                    "blockindex": 3,
+                    "transfernotifyindex": 0,
+                    "txhash": "0xe42108b343626035cb51fbcb54949bb38aac50c8ba278841d304e9fdce0807ac"
+                }
+            ],
+            "address": "NikhQp1aAD1YFCiwknhM5LQQebj4464bCJ"
+        }
+
+        self.mock_response(captured)
+
+        response = await self.client.get_nep17_transfers("bogus_addr")
+        self.assertEqual(2, len(response.received))
+        self.assertEqual(100, response.received[0].amount)
+
+    async def test_get_raw_mempool(self):
+        tx1_hash = "0x0c65fbfd2598aee5f30cd18f1264b458f1db137c4a460f4a174facb3f2d59d06"
+        tx2_hash = "0xc8040c285aa495f5b5e5b3761fd9333899f4ed902951c46d86c3bbb1cb12f2c0"
+
+        resp = {
+            "height": 5882071,
+            "verified": [tx1_hash, tx2_hash],
+            "unverified": []
+        }
+        self.mock_response(resp)
+
+        expected_verified = [
+            types.UInt256.from_string(tx1_hash[2:]),
+            types.UInt256.from_string(tx2_hash[2:])
+        ]
+        response = await self.client.get_raw_mempool()
+        self.assertEqual(expected_verified, response.verified)
+
+    async def test_get_next_block_validators(self):
+        votes = 660174
+        pub_key_raw = "02237309a0633ff930d51856db01d17c829a5b2e5cc2638e9c03b4cfa8e9c9f971"
+        public_key = cryptography.ECPoint.deserialize_from_bytes(bytes.fromhex(pub_key_raw))
+
+        resp = [{
+            "publickey": pub_key_raw,
+            "votes": str(votes),
+            "active": False
+        }]
+        self.mock_response(resp)
+
+        response = await self.client.get_next_blockvalidators()
+        self.assertEqual(1, len(response.validators))
+        self.assertEqual(votes, response.validators[0].votes)
+        self.assertEqual(public_key, response.validators[0].public_key)
+
+    async def test_get_peers(self):
+        peer1 = {"address": "47.90.28.99", "port": 21333}
+        peer2 = {"address": "47.91.28.99", "port": 22333}
+
+        resp = {
+            "unconnected": [],
+            "bad": [],
+            "connected": [peer1, peer2]
+        }
+        self.mock_response(resp)
+
+        response = await self.client.get_peers()
+        self.assertEqual(2, len(response.connected))
+        self.assertEqual(peer1['address'], response.connected[0].address)
+        self.assertEqual(peer1['port'], response.connected[0].port)
+        self.assertEqual(peer2['address'], response.connected[1].address)
+        self.assertEqual(peer2['port'], response.connected[1].port)
+
+    async def test_get_storage(self):
+        storage_value = b'\x01\x02\x03'
+
+        self.mock_response(base64.b64encode(storage_value).decode())
+
+        dummy_contract_hash = types.UInt160.from_string("0x99042d380f2b754175717bb932a911bc0bb0ad7d"[2:])
+        response = await self.client.get_storage(dummy_contract_hash, key=b'\x11')
+        self.assertEqual(storage_value, response)
+
+    async def test_get_transaction(self):
+        tx = payloads.Transaction._serializable_init()
+        # set some properties to ensure the TX will pass the deserialization checks
+        tx.signers.append(payloads.Signer._serializable_init())
+        tx.script = b'\x01'
+        tx.witnesses = [payloads.Witness._serializable_init()]
+
+        self.mock_response(base64.b64encode(tx.to_array()).decode())
+
+        response_tx = await self.client.get_transaction(tx.hash())
+        self.assertEqual(tx, response_tx)
+
+    async def test_get_tx_height(self):
+        height = 1
+        tx_hash = "0c65fbfd2598aee5f30cd18f1264b458f1db137c4a460f4a174facb3f2d59d06"
+        self.mock_response(height)
+        response = await self.client.get_transaction_height(tx_hash)
+        self.assertEqual(height, response)
+
+    async def test_get_unclaimed_gas_(self):
+        addr = "NgaiKFjurmNmiRzDRQGs44yzByXuSkdGPF"
+        value = 100
+        self.mock_response({"unclaimed": str(value)})
+        response_value = await self.client.get_unclaimed_gas(addr)
+        self.assertEqual(value, response_value)
+
+    async def test_get_version(self):
+        user_agent = "/Neo:3.0.3/"
+        captured = {
+            "tcpport": 10333,
+            "wsport": 10334,
+            "nonce": 1930156121,
+            "useragent": user_agent,
+            "protocol": {
+                "addressversion": 53,
+                "network": 860833102,
+                "validatorscount": 7,
+                "msperblock": 15000,
+                "maxtraceableblocks": 2102400,
+                "maxvaliduntilblockincrement": 5760,
+                "maxtransactionsperblock": 512,
+                "memorypoolmaxtransactions": 50000,
+                "initialgasdistribution": 5200000000000000
+            }
+        }
+        self.mock_response(captured)
+        response = await self.client.get_version()
+        self.assertEqual(user_agent, response.useragent)
+
+    async def test_invoke_contract_verify(self):
+        captured = {
+            "script": "VgEMFFbIjRQK0swPKQN90Qp/AGCitShcYEBXAANAQZv2Z84MBWhlbGxvDAV3b3JsZFNB5j8YhEBXAQAMFFbIjRQK0swPKQN90Qp/AGCitShcQfgn7IxwaEA=",
+            "state": "HALT",
+            "gasconsumed": "1017810",
+            "exception": None,
+            "stack": [
+                {
+                    "type": "Boolean",
+                    "value": True
+                }
+            ]
+        }
+
+        self.mock_response(captured)
+
+        contract_hash = "92f5c79b88560584a900cfec15b0e00dc4d58b59"
+        response = await self.client.invoke_contract_verify(contract_hash)
+        self.assertEqual(1, len(response.stack))
+        self.assertTrue(response.stack[0].value)
+
+    async def test_invoke_function(self):
+        captured = {
+            "script": "VgEMFFbIjRQK0swPKQN90Qp/AGCitShcYEBXAANAQZv2Z84MBWhlbGxvDAV3b3JsZFNB5j8YhEBXAQAMFFbIjRQK0swPKQN90Qp/AGCitShcQfgn7IxwaEA=",
+            "state": "HALT",
+            "gasconsumed": "1017810",
+            "exception": None,
+            "stack": [
+                {
+                    "type": "Boolean",
+                    "value": True
+                }
+            ]
+        }
+
+        self.mock_response(captured)
+
+        contract_hash = "92f5c79b88560584a900cfec15b0e00dc4d58b59"
+        response = await self.client.invoke_function(contract_hash, "dummy_func")
+        self.assertEqual(1, len(response.stack))
+        self.assertTrue(response.stack[0].value)
+
+    async def test_invoke_script(self):
+        captured = {
+            "script": "VgEMFFbIjRQK0swPKQN90Qp/AGCitShcYEBXAANAQZv2Z84MBWhlbGxvDAV3b3JsZFNB5j8YhEBXAQAMFFbIjRQK0swPKQN90Qp/AGCitShcQfgn7IxwaEA=",
+            "state": "HALT",
+            "gasconsumed": "1017810",
+            "exception": None,
+            "stack": [
+                {
+                    "type": "Boolean",
+                    "value": True
+                }
+            ]
+        }
+
+        self.mock_response(captured)
+
+        bogus_script = b'\x01'
+        response = await self.client.invoke_script(bogus_script)
+        self.assertEqual(1, len(response.stack))
+        self.assertTrue(response.stack[0].value)
+
+    async def test_send_tx(self):
+        tx = payloads.Transaction._serializable_init()
+        hash_ = "0x13ccdb9f7eda95a24aa5a4841b24fed957fe7f1b944996cbc2e92a4fa4f1fa73"
+        hash_type = types.UInt256.from_string(hash_[2:])
+        bogus_response = {"hash": hash_}
+        self.mock_response(bogus_response)
+        response_tx_id = await self.client.send_transaction(tx)
+        self.assertEqual(hash_type, response_tx_id)
+
+    async def test_send_block(self):
+        block = payloads.Block._serializable_init()
+        hash_ = "0x13ccdb9f7eda95a24aa5a4841b24fed957fe7f1b944996cbc2e92a4fa4f1fa73"
+        hash_type = types.UInt256.from_string(hash_[2:])
+        bogus_response = {"hash": hash_}
+        self.mock_response(bogus_response)
+        response_block_id = await self.client.send_block(block)
+        self.assertEqual(hash_type, response_block_id)
+
+    async def test_validate_address(self):
+        addr = "NPvKVTGZapmFWABLsyvfreuqn73jCjJtN1"
+        resp = {
+            "address": addr,
+            "isvalid": True
+        }
+        self.mock_response(resp)
+        response = await self.client.validate_address(addr)
+        self.assertTrue(response)
+
+    async def test_exception(self):
+        with self.assertRaises(api.JsonRpcError) as context:
+            error_response = {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": {
+                    "code": -2146233086,
+                    "message": "bogus_message",
+                    "data": "bogus_data"
+                }
+            }
+            self.helper.post('localhost', payload=error_response)
+            await self.client.validate_address("abc")
+        self.assertIn("-2146233086", str(context.exception))
+        self.assertIn("bogus_message", str(context.exception))
+        self.assertIn("bogus_data", str(context.exception))


### PR DESCRIPTION
This adds the base Neo Node RPC methods. Note that not all method names match 1:1. e.g. `sendrawtransaction` is not mapped to `send_raw_transaction()` but to `send_transaction()`. The latter accepts either a `Transaction` object or a serialised version of a transaction.

I'm looking for some feedback on API usage. It makes sense to me but I'm obviously biased.

Example usage:
```python
from neo3 import api


async def main():
    url = "https://mainnet5.neo.coz.io:443"
    async with api.NeoRpcClient(url) as client:
        try:
            print(await client.get_version())
        except api.JsonRpcError as e:
            print(e)

if __name__ == "__main__":
    asyncio.run(main())
```

TODO:
- [x] add `getapplicationlogs` method
- [x] fix type checker
- [ ] usage documentation
- [x] test coverage

Not convinced yet if its worth the effort (time wise):
- We do not perform any JSON response validation prior to parsing. This could mean we throw unfriendly errors if the node replies with bogus data, or the node side had updates (i.e. renamed/delete/new keys). Note that `neon-js` also doesn't check this, so we're not doing less than our other tools/sdks

## Methods not (yet) supported
**state service**
- getproof
- verifyproof
- findstates
- getstateroot
- getstateheight
- getstate

**requires an open wallet**
-  openwallet
-  sendfrom
-  sendmany
-  sendtoaddress
-  closewallet
-  dumpprivkey
-  getnewaddress
-  importprivkey
-  getwalletbalance
-  getwalletunclaimedgas
-  listaddress

## Method not going to be supported
- listplugins -> too node implementation specific e.g. NEO-cli/rpc returns C# interface names (and neo-go doesn't support it at all)
- getnativecontracts -> all native contracts already exist in mamba itself. 
