### PR TITLE
Audit 321

### DIFF
--- a/neo3/contracts/native/crypto.py
+++ b/neo3/contracts/native/crypto.py
@@ -35,7 +35,10 @@ class CryptoContract(NativeContract):
 
     @register("verifyWithECDsa", contracts.CallFlags.NONE, cpu_price=1 << 15)
     def verify_with_ecdsa(self, message: bytes, public_key: bytes, signature: bytes, curve: NamedCurve) -> bool:
-        return cryptography.verify_signature(message, signature, public_key, self.curves.get(curve))
+        try:
+            return cryptography.verify_signature(message, signature, public_key, self.curves.get(curve))
+        except cryptography.ECCException:
+            return False
 
     @register("murmur32", contracts.CallFlags.NONE, cpu_price=1 << 13)
     def murmur32(self, data: bytes, seed: int) -> bytes:

--- a/neo3/contracts/native/stdlib.py
+++ b/neo3/contracts/native/stdlib.py
@@ -58,7 +58,16 @@ class StdLibContract(NativeContract):
         if base != 10 and base != 16:
             raise ValueError("Invalid base specified")
         else:
-            return int(value, base)
+            if base == 10:
+                return int(value, base)
+            else:
+                if padded := (len(value) % 2 != 0):
+                    value = '0' + value
+                b = bytearray.fromhex(value)
+                if padded and b[0] & 0x8 != 0:
+                    b[0] |= 0xF0
+                b.reverse()
+                return int(vm.BigInteger(b))
 
     @register("base64Encode", contracts.CallFlags.NONE, cpu_price=1 << 5)
     def base64_encode(self, data: bytes) -> str:


### PR DESCRIPTION
Fix testnet block `111150`  - graceful handling of ECDSA verify failure
Fix testnet block `1169851 - correctly handle base 16 input for Atoi
