### PR TITLE
Fix wallet & reduce test time

### DIFF
--- a/neo3/wallet/wallet.py
+++ b/neo3/wallet/wallet.py
@@ -102,7 +102,8 @@ class Wallet(IJson):
         """
         account = Account(password=password,
                           watch_only=False,
-                          label=label
+                          label=label,
+                          scrypt_parameters=self.scrypt
                           )
 
         self.account_add(account, is_default)
@@ -290,19 +291,20 @@ class Wallet(IJson):
 
         accounts = []
         default_account = None
+        scrypt_params = ScryptParameters.from_json(json['scrypt'])
         if len(json['accounts']) > 0:
             if password is None:
                 raise ValueError('Missing wallet password to decrypt account data')
             else:
                 for json_account in json['accounts']:
-                    account_from_json = Account.from_json(json_account, password)
+                    account_from_json = Account.from_json(json_account, password, scrypt_parameters=scrypt_params)
                     accounts.append(account_from_json)
                     if default_account is None and hasattr(json, 'isDefault') and json['isDefault']:
                         default_account = account_from_json
 
         return cls(name=json['name'],
                    version=json['version'],
-                   scrypt=ScryptParameters.from_json(json['scrypt']),
+                   scrypt=scrypt_params,
                    accounts=accounts,
                    default_account=default_account,
                    extra=json['extra'])

--- a/tests/wallet/test_account.py
+++ b/tests/wallet/test_account.py
@@ -1,6 +1,6 @@
 import unittest
 
-from neo3.wallet import Account
+from neo3.wallet import Account, ScryptParameters
 
 account_list = [
     {
@@ -9,31 +9,25 @@ account_list = [
         "password": "city of zion",
         "private_key": "58124574dfcca1a7a958775f6ea94e3d6c392ec3ba125b5bc591dd5e14f05e52",
         "script_hash": "18f13748e08d53c9a164227e1a3e8d8d9e78193e",
-        "wif_key": "KzAuju4yBqBhmUzYpfEEppPW8jfxALTsdsUR8hLPv9R3PBD97CUv"      
+        "wif_key": "KzAuju4yBqBhmUzYpfEEppPW8jfxALTsdsUR8hLPv9R3PBD97CUv"
     },
     {
         "address": "NgPptMp2tcjnXuYbUrTozvwvLExGKk5jXc",
-        "encrypted_key": "6PYMEujkLs249znmr3v59x3M12iPbdPTZftv8f2TapuLyHn8TQBZLVJUV6",
+        "encrypted_key": "6PYMEujkLZiJrQ5AK9W4z1BtYZT2U27ZVKrjbEFt8zZh5CJANZdEx21Fyx",
         "password": "123",
         "private_key": "2032b737522d22e2b6faf30555faa91d95c5aa5113c18f218f45815b6934c558",
         "script_hash": "cfa9032d65b3d0fc1df3956a4ef01666f23ba7e0",
-        "wif_key": "KxJJLmU1Nv7igx3RFM4siSvio7wasF3ZzMzi7SrJ1s78QDQeEtjs"
+        "wif_key": "KxJJLmU1Nv7igx3RFM4siSvio7wasF3ZzMzi7SrJ1s78QDQeEtjs",
+        "scrypt": {"n": 2, "r": 8, "p": 8}
     },
     {
         "address": "NZMHRJMPbyJJwtXpvS2mYAWcWp4qmZZFx8",
-        "encrypted_key": "6PYL44vbS5e6ubYtV3JqDM7J92gCEYXWewVyFdyki6JLcQ7QaYzsW6YjTs",
+        "encrypted_key": "6PYL44vbRemjfwCJ8qprKKJJiuzcopnJhghPoMLRVJLpymDwm2BNj9v7fq",
         "password": "neo",
         "private_key": "4c5182d9041f416bee1a6adac6a03f3e0319a83e75e78e6ff739304095791f19",
         "script_hash": "0df27baba6baeeb6834bea0d6c2a78183b416393",
-        "wif_key": "Kyn4fA6czAhktoAM9YXKv3m7jtt47AuQxCXqSusnBmj3GsZUZQ6M"
-    },
-    {
-        "address": "NWxsLx9BFA558pVLZmFNuYsRKuXMMi2QSQ",
-        "encrypted_key": "6PYQ5gTPAv4p5nfrb2ywPumSdtiXCjimuwDAbv93FPancd1dU9D9ajkPqd",
-        "password": "neo-mamba",
-        "private_key": "1c43f87ce2ce3ea676bdfec4928705f3e9fedbdb3acf1fed6b3cc0c3d87c4cad",
-        "script_hash": "3b951421e8dc81552df3af1478ef72b05bc13579",
-        "wif_key": "KxAexpL1F8FAoG72LCDkerLa8SKLutUSLafALB5zvdQ2asuRf6Wx"
+        "wif_key": "Kyn4fA6czAhktoAM9YXKv3m7jtt47AuQxCXqSusnBmj3GsZUZQ6M",
+        "scrypt": {"n": 2, "r": 8, "p": 8}
     }
 ]
 
@@ -41,8 +35,11 @@ account_list = [
 class AccountCreationTestCase(unittest.TestCase):
 
     def test_new_account(self):
-        for testcase in account_list:
-            account = Account(testcase['password'])
+        for testcase in account_list[1:]:
+            scrypt_params = testcase.get("scrypt", None)
+            if scrypt_params is not None:
+                scrypt_params = ScryptParameters.from_json(scrypt_params)
+            account = Account(testcase['password'], scrypt_parameters=scrypt_params)
             self.assertIsNotNone(account)
             self.assertIsNotNone(account.address)
             self.assertIsNotNone(account.encrypted_key)
@@ -50,15 +47,22 @@ class AccountCreationTestCase(unittest.TestCase):
 
     def test_new_account_from_private_key(self):
         for testcase in account_list:
-            account = Account.from_private_key(bytes.fromhex(testcase['private_key']), testcase['password'])
+            scrypt_params = testcase.get("scrypt", None)
+            if scrypt_params is not None:
+                scrypt_params = ScryptParameters.from_json(scrypt_params)
+            account = Account.from_private_key(bytes.fromhex(testcase['private_key']), testcase['password'], scrypt_params)
             self.assertEqual(testcase['address'], account.address)
             self.assertEqual(testcase['encrypted_key'].encode('utf-8'), account.encrypted_key)
             self.assertEqual(testcase['script_hash'], str(account.script_hash))
             self.assertIsNotNone(account.public_key)
 
     def test_new_account_from_encrypted_key(self):
-        for testcase in account_list:
-            account = Account.from_encrypted_key(testcase['encrypted_key'], testcase['password'])
+        for testcase in account_list[1:]:
+            scrypt_params = testcase.get("scrypt", None)
+            if scrypt_params is not None:
+                scrypt_params = ScryptParameters.from_json(scrypt_params)
+
+            account = Account.from_encrypted_key(testcase['encrypted_key'], testcase['password'], scrypt_params)
             self.assertEqual(testcase['address'], account.address)
             self.assertEqual(testcase['encrypted_key'].encode('utf-8'), account.encrypted_key)
             self.assertEqual(testcase['script_hash'], str(account.script_hash))
@@ -66,7 +70,7 @@ class AccountCreationTestCase(unittest.TestCase):
 
     def test_new_watch_only_account(self):
         from neo3.core.types import UInt160
-        for testcase in account_list:
+        for testcase in account_list[1:]:
             account = Account.watch_only(UInt160.from_string(testcase['script_hash']))
             self.assertEqual(testcase['address'], account.address)
             self.assertIsNone(account.encrypted_key)
@@ -74,7 +78,7 @@ class AccountCreationTestCase(unittest.TestCase):
             self.assertIsNone(account.public_key)
 
     def test_new_watch_only_account_from_address(self):
-        for testcase in account_list:
+        for testcase in account_list[1:]:
             account = Account.watch_only_from_address(testcase['address'])
             self.assertEqual(testcase['address'], account.address)
             self.assertIsNone(account.encrypted_key)
@@ -82,20 +86,19 @@ class AccountCreationTestCase(unittest.TestCase):
             self.assertIsNone(account.public_key)
 
     def test_new_account_from_wif(self):
-        for testcase in account_list:
-            account = Account.from_wif(testcase['wif_key'], testcase['password'])
+        for testcase in account_list[:1]:
+            scrypt_params = testcase.get("scrypt", None)
+            if scrypt_params is not None:
+                scrypt_params = ScryptParameters.from_json(scrypt_params)
+
+            account = Account.from_wif(testcase['wif_key'], testcase['password'], scrypt_params)
             self.assertEqual(testcase['address'], account.address)
             self.assertEqual(testcase['encrypted_key'].encode('utf-8'), account.encrypted_key)
             self.assertEqual(testcase['script_hash'], str(account.script_hash))
             self.assertIsNotNone(account.public_key)
 
     def test_new_account_wrong_password(self):
-        wrong_password: bool = True
         for testcase in account_list:
-            try:
+            with self.assertRaises(ValueError) as context:
                 Account.from_encrypted_key(testcase['encrypted_key'], "wrong password")
-                wrong_password = False
-            except ValueError:
-                continue
-
-        self.assertEqual(True, wrong_password)
+            self.assertIn("Wrong passphrase", str(context.exception))


### PR DESCRIPTION
- Fix Scrypt parameters configured for a `Wallet` were not actually used when encrypting/decrypting the accounts. It always used the default NEP-2 params
- Allow specifying custom scrypt parameters in the alternative constructors
- Reduce wallet test time by ~3x

close #150