### PR TITLE
examples, api: improve deploy/transfer feedback

### DIFF
--- a/examples/cli/deploy.py
+++ b/examples/cli/deploy.py
@@ -9,12 +9,13 @@ import sys
 import asyncio
 import json
 import argparse
+from typing import Optional
 from neo3 import api, wallet, contracts
-from neo3.contracts import vm
+from neo3.contracts import vm, get_contract_hash
 from neo3.network import payloads
 
 
-async def main(wallet_path, wallet_pw, nef_path, manifest_path, rpc_host):
+async def main(wallet_path, wallet_pw, nef_path, manifest_path, rpc_host, poll_timeout: Optional[str] = None):
     with open(wallet_path) as f:
         data = json.load(f)
         w = wallet.Wallet.from_json(data, password=wallet_pw)
@@ -23,12 +24,16 @@ async def main(wallet_path, wallet_pw, nef_path, manifest_path, rpc_host):
     with open(nef_path, 'rb') as f:
         nef_bytes = f.read()
         try:
-            contracts.NEF.deserialize_from_bytes(nef_bytes)
+            nef = contracts.NEF.deserialize_from_bytes(nef_bytes)
         except ValueError as e:
             raise ValueError(f"Failed NEF file validation with: {e}")
 
     with open(manifest_path, 'rb') as f:
         manifest_bytes = f.read()
+        try:
+            manifest = contracts.ContractManifest.deserialize_from_bytes(manifest_bytes)
+        except ValueError as e:
+            raise ValueError(f"Failed manifest validation with: {e}")
 
     # build a contract deploy transaction
     sb = vm.ScriptBuilder()
@@ -63,10 +68,19 @@ async def main(wallet_path, wallet_pw, nef_path, manifest_path, rpc_host):
             res = await client.get_version()
             account.sign_tx(tx, password=wallet_pw, magic=res.protocol.network)
             tx_id = await client.send_transaction(tx)
+            print(f"Contract hash: {get_contract_hash(tx.sender, nef.checksum, manifest.name)}")
             print(f"Transaction id: {tx_id}")
+            if poll_timeout is not None:
+                status = await api.poll_tx_status(tx_id, client)
+                if status == vm.VMState.HALT:
+                    print(f"Transaction execution status: Success")
+                else:
+                    print(f"Transaction execution status: Failed (VMState: {status})")
+
         except api.JsonRpcError as e:
             print(e)
-            sys.exit(1)
+            sys.exit(-1)
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Deploy contract')
@@ -74,7 +88,10 @@ if __name__ == "__main__":
     parser.add_argument("-pw", metavar='PASSWORD', required=True, help="wallet password for signing")
     parser.add_argument("-c", metavar='CONTRACT_NEF', required=True, help="contract .NEF path")
     parser.add_argument("-m", metavar='CONTRACT_MANIFEST', required=True, help="contract .manifest.json path")
-    parser.add_argument("-s", metavar='RPC_SERVER', required=True, help="RPC server address e.g. https://mainnet1.neo.coz.io:443")
+    parser.add_argument("-s", metavar='RPC_SERVER', required=True,
+                        help="RPC server address e.g. https://mainnet1.neo.coz.io:443")
+    parser.add_argument("-p", metavar='TIMEOUT_IN_SECONDS', type=int, help="Poll for transaction status after "
+                                                                           "deployment. Default timeout is 20 seconds")
     args = parser.parse_args()
 
-    asyncio.run(main(args.w, args.pw, args.c, args.m, args.s))
+    asyncio.run(main(args.w, args.pw, args.c, args.m, args.s, args.p))

--- a/examples/cli/deploy.py
+++ b/examples/cli/deploy.py
@@ -91,7 +91,8 @@ if __name__ == "__main__":
     parser.add_argument("-c", metavar='CONTRACT_NEF', required=True, help="contract .NEF path")
     parser.add_argument("-m", metavar='CONTRACT_MANIFEST', required=True, help="contract .manifest.json path")
     parser.add_argument("-s", metavar='RPC_SERVER', required=True,
-                        help="RPC server address e.g. https://mainnet1.neo.coz.io:443")
+                        help="RPC server address e.g. https://testnet1.neo.coz.io:443 See https://dora.coz.io/monitor "
+                             "for more servers and for different networks")
     parser.add_argument("-p", metavar='TIMEOUT_IN_SECONDS', nargs='?', const=20, type=int,
                         help="Poll for transaction status after deployment. Default timeout is 20 seconds")
     args = parser.parse_args()

--- a/neo3/api/__init__.py
+++ b/neo3/api/__init__.py
@@ -1,3 +1,3 @@
-from .noderpc import NeoRpcClient, JsonRpcError
+from .noderpc import NeoRpcClient, JsonRpcError, poll_tx_status
 
 __all__ = ['NeoRpcClient', 'JsonRpcError']

--- a/neo3/api/noderpc.py
+++ b/neo3/api/noderpc.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 import aiohttp
 import base64
+import asyncio
 from dataclasses import dataclass
 from typing import Optional, TypedDict, Any, Protocol, Iterator, Union
 import datetime
+import time
 from neo3 import contracts
+from neo3.contracts import vm
 from neo3.network import payloads
 from neo3.core import types, cryptography, IJson
 
@@ -310,20 +313,34 @@ class ApplicationExecution(ExecutionResult):
 
 
 @dataclass
-class AppliationLogResponse:
-    tx_id: types.UInt256
+class TransactionApplicationLogResponse:
+    tx_hash: types.UInt256
+    execution: ApplicationExecution
+
+    @classmethod
+    def from_json(cls, json: dict):
+        tx_id = types.UInt256.from_string(json['txid'])
+        return cls(tx_id, json['executions'][0])
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(tx_hash={str(self.tx_hash)}, execution={self.execution})"
+
+
+@dataclass
+class BlockApplicationLogResponse:
+    block_hash: types.UInt256
     executions: list[ApplicationExecution]
 
     @classmethod
     def from_json(cls, json: dict):
-        tx_id = types.UInt256.from_string(json['txid'][2:])
+        block_hash = types.UInt256.from_string(json['blockhash'])
         executions = []
         for execution in json['executions']:
-            executions.append(ApplicationExecution.from_json(execution))
-        return cls(tx_id, executions)
+            executions.append(execution)
+        return cls(block_hash, executions)
 
     def __repr__(self):
-        return f"{self.__class__.__name__}(tx_id={str(self.tx_id)}, executions={self.executions})"
+        return f"{self.__class__.__name__}(block_hash={str(self.block_hash)}, executions={self.executions})"
 
 
 ContractParameter = Union[bool, int, str, bytes, bytearray, types.UInt160, types.UInt256, cryptography.ECPoint,
@@ -445,6 +462,17 @@ class JsonRpcError(Exception):
             return f"code={self.code}, message={self.message}"
 
 
+class JsonRpcTimeoutError(JsonRpcError):
+    def __init__(self, message: str = None):
+        self.message = message
+
+    def __str__(self):
+        if self.message is None:
+            return "Operation timed out"
+        else:
+            return self.message
+
+
 class NeoRpcClient(RPCClient):
     def __init__(self, host: str, **kwargs):
         super(NeoRpcClient, self).__init__(host, **kwargs)
@@ -467,7 +495,7 @@ class NeoRpcClient(RPCClient):
         result = await self._do_post("calculatenetworkfee", params)
         return int(result['networkfee'])
 
-    async def get_application_log(self, tx_hash: types.UInt256 | str) -> AppliationLogResponse:
+    async def get_application_log_transaction(self, tx_hash: types.UInt256 | str) -> TransactionApplicationLogResponse:
         """
         Fetch the smart contract event logs for a given transaction.
 
@@ -479,7 +507,19 @@ class NeoRpcClient(RPCClient):
         if isinstance(tx_hash, types.UInt256):
             tx_hash = f"0x{str(tx_hash)}"
         result = await self._do_post("getapplicationlog", [tx_hash])
-        return AppliationLogResponse.from_json(result)
+        return TransactionApplicationLogResponse.from_json(result)
+
+    async def get_application_log_block(self, block_hash: types.UInt256 | str) -> BlockApplicationLogResponse:
+        """
+        Fetch the system event logs for a given block.
+
+        Args:
+            block_hash: the hash of the block to query for.
+        """
+        if isinstance(block_hash, types.UInt256):
+            block_hash = f"0x{str(block_hash)}"
+        result = await self._do_post("getapplicationlog", [block_hash])
+        return BlockApplicationLogResponse.from_json(result)
 
     async def get_best_block_hash(self) -> types.UInt256:
         """
@@ -873,3 +913,16 @@ class NeoRpcClient(RPCClient):
             return "ContractParam"
         else:
             return f"Unknown({str(p)}"
+
+
+async def poll_tx_status(tx_id: types.UInt256, client: NeoRpcClient, timeout=20) -> vm.VMState:
+    start = time.time()
+    while time.time() - start > timeout:
+        try:
+            log = await client.get_application_log_transaction(tx_id)
+            break
+        except JsonRpcError:
+            await asyncio.sleep(5)
+    else:
+        raise JsonRpcTimeoutError(f"Could not find transaction {tx_id} within specified timeout of {timeout} seconds")
+    return vm.VMState(log.execution.state)

--- a/neo3/contracts/__init__.py
+++ b/neo3/contracts/__init__.py
@@ -59,4 +59,5 @@ __all__ = ['ContractParameterType',
            'syscall_name_to_int',
            'NEF',
            'MethodToken',
-           'FindOptions']
+           'FindOptions',
+           'get_contract_hash']

--- a/neo3/contracts/__init__.py
+++ b/neo3/contracts/__init__.py
@@ -17,7 +17,8 @@ from .nef import (NEF, MethodToken)
 from .contract import (Contract, ContractState)
 from .findoptions import FindOptions
 from dataclasses import dataclass
-from neo3.core import types
+from neo3.core import types, to_script_hash
+from . import vm
 
 
 @dataclass
@@ -39,6 +40,15 @@ def validate_type(obj: object, type_: typing.Type):
     return obj
 
 
+def get_contract_hash(sender: types.UInt160, nef_checksum: int, contract_name: str) -> types.UInt160:
+    sb = vm.ScriptBuilder()
+    sb.emit(vm.OpCode.ABORT)
+    sb.emit_push(sender)
+    sb.emit_push(nef_checksum)
+    sb.emit_push(contract_name)
+    return to_script_hash(sb.to_array())
+
+
 __all__ = ['ContractParameterType',
            'ContractMethodDescriptor',
            'ContractEventDescriptor',
@@ -49,6 +59,4 @@ __all__ = ['ContractParameterType',
            'syscall_name_to_int',
            'NEF',
            'MethodToken',
-           'FindOptions',
-           'ScriptBuilder',
-           'VMState']
+           'FindOptions']

--- a/neo3/contracts/vm.py
+++ b/neo3/contracts/vm.py
@@ -403,3 +403,17 @@ class VMState(IntEnum):
     HALT = 1 << 0
     FAULT = 1 << 1
     BREAK = 1 << 2
+
+    @staticmethod
+    def from_string(value: str) -> VMState:
+        match value:
+            case 'NONE':
+                return VMState.NONE
+            case 'HALT':
+                return VMState.HALT
+            case 'FAULT':
+                return VMState.FAULT
+            case 'BREAK':
+                return VMState.BREAK
+            case _:
+                raise ValueError(f"{value} cannot be converted to VMState")

--- a/neo3/core/cryptography/bloomfilter.py
+++ b/neo3/core/cryptography/bloomfilter.py
@@ -1,5 +1,5 @@
 from bitarray import bitarray  # type: ignore
-import mmh3  # type: ignore
+from neo3crypto import mmh3_hash  # type: ignore
 
 
 class BloomFilter:
@@ -37,7 +37,7 @@ class BloomFilter:
             element: hex-escaped bytearray.
         """
         for s in self.seeds:
-            h = mmh3.hash(element, s, signed=False)
+            h = mmh3_hash(element, s, signed=False)
             self.bits[h % len(self.bits)] = True
 
     def check(self, element: bytes) -> bool:
@@ -50,7 +50,7 @@ class BloomFilter:
         Returns: True if present. False if not present.
         """
         for s in self.seeds:
-            h = mmh3.hash(element, s, signed=False)
+            h = mmh3_hash(element, s, signed=False)
             if not self.bits[h % len(self.bits)]:
                 return False
         return True

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,10 +35,10 @@ install_requires =
 	asynctest==0.13.0
 	aioresponses==0.7.2
 	base58==2.1.0
-	bitarray==2.3.4
+	bitarray==2.6.0
 	Events==0.4
 	jsonschema>=3.2.0
-	lz4==3.1.3
+	lz4==4.0.2
 	mmh3==3.0.0
 	neo3crypto==0.2.2
 	netaddr>=0.8.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,8 +39,7 @@ install_requires =
 	Events==0.4
 	jsonschema>=3.2.0
 	lz4==4.0.2
-	mmh3==3.0.0
-	neo3crypto==0.2.2
+	neo3crypto==0.3
 	netaddr>=0.8.0
 	orjson>=3.4.6
 	pycryptodome==3.11.0

--- a/tests/contracts/test_utils.py
+++ b/tests/contracts/test_utils.py
@@ -1,0 +1,15 @@
+import unittest
+from neo3.contracts import get_contract_hash, NEF
+from neo3.core import types
+
+
+class TestContractUtils(unittest.TestCase):
+    def test_get_contract_hash(self):
+        nef = NEF("test", b'\x01\x02\x03')
+        actual = get_contract_hash(types.UInt160.zero(), nef.checksum, "test")
+        expected = types.UInt160.from_string("0x576c9c6f22eea8fd823155b00141a4327bac8263")
+        self.assertEqual(expected, actual)
+
+        actual = get_contract_hash(types.UInt160.from_string("0xa400ff00ff00ff00ff00ff00ff00ff00ff00ff01"), nef.checksum, "test")
+        expected = types.UInt160.from_string("0x55f776130883b2d486dec295ca74533663d0f8ea")
+        self.assertEqual(expected, actual)

--- a/tests/core/test_cryptography.py
+++ b/tests/core/test_cryptography.py
@@ -1,7 +1,7 @@
 import unittest
 import binascii
 import hashlib
-import mmh3
+from neo3crypto import mmh3_hash_bytes, mmh3_hash
 from neo3.core import types
 from neo3.core import cryptography as crypto
 
@@ -106,12 +106,12 @@ class Murmur128test(unittest.TestCase):
 
     def test_neo_cases(self):
         # https://github.com/Liaojinghui/neo/blob/30f33d075502acd792f804ffcf84cce689255306/tests/neo.UnitTests/Cryptography/UT_Murmur128.cs
-        self.assertEqual(bytes.fromhex("0bc59d0ad25fde2982ed65af61227a0e"), mmh3.hash_bytes("hello", 123))
-        self.assertEqual(bytes.fromhex("3d3810fed480472bd214a14023bb407f"), mmh3.hash_bytes("world", 123))
-        self.assertEqual(bytes.fromhex("e0a0632d4f51302c55e3b3e48d28795d"), mmh3.hash_bytes("hello world", 123))
+        self.assertEqual(bytes.fromhex("0bc59d0ad25fde2982ed65af61227a0e"), mmh3_hash_bytes("hello", 123))
+        self.assertEqual(bytes.fromhex("3d3810fed480472bd214a14023bb407f"), mmh3_hash_bytes("world", 123))
+        self.assertEqual(bytes.fromhex("e0a0632d4f51302c55e3b3e48d28795d"), mmh3_hash_bytes("hello world", 123))
 
 
 class MurMur32test(unittest.TestCase):
     def test_one(self):
-        x: int = mmh3.hash(b'\x01\x02\x03\x04\x05\x06', 123, signed=False)
+        x: int = mmh3_hash(b'\x01\x02\x03\x04\x05\x06', 123, signed=False)
         self.assertEqual(bytes.fromhex("3cdc1e41"), x.to_bytes(4, 'little', signed=False))


### PR DESCRIPTION
On successful execution of the deploy and transfer CLI examples one would only get a transaction id. A transaction id does not guarantee success on chain. This PR improves the feedback
   * added `-p` option to the scripts to poll the chain for the transaction status with a 20 second timeout (can be specified)
   * the deploy script now prints the `contract hash`
   * added `poll_tx_status()` helper function
   
