### PR TITLE
api: add base contract wrappers

### DIFF
--- a/neo3/api/noderpc.py
+++ b/neo3/api/noderpc.py
@@ -237,6 +237,12 @@ class StackItem:
             raise ValueError(f"item is not of type 'Array' but of type '{self.type}'")
         return cast(list, self.value)
 
+    def as_dict(self) -> dict:
+        if self.type != "Map":
+            raise ValueError(f"item is not of type 'Map' but of type '{self.type}'")
+        m = cast(MapStackItem, self)
+        return dict(m.items())
+
 
 class MapStackItem(StackItem):
     def items(self) -> Iterator:

--- a/neo3/api/noderpc.py
+++ b/neo3/api/noderpc.py
@@ -232,6 +232,11 @@ class StackItem:
             data = bytes.fromhex(data.decode())
         return cryptography.ECPoint.deserialize_from_bytes(data, validate=True)
 
+    def as_list(self) -> list:
+        if self.type != "Array":
+            raise ValueError(f"item is not of type 'Array' but of type '{self.type}'")
+        return cast(list, self.value)
+
 
 class MapStackItem(StackItem):
     def items(self) -> Iterator:

--- a/neo3/api/unwrap.py
+++ b/neo3/api/unwrap.py
@@ -131,9 +131,23 @@ def as_list(res: noderpc.ExecutionResult, idx: int = 0) -> list:
         idx: the index in the result stack to fetch the stack item from.
 
     Raises:
-        ValueError: if the index is out of range, or the value cannot be converted to a bool
+        ValueError: if the index is out of range, or the value cannot be converted to a list
     """
     return item(res, idx).as_list()
+
+
+def as_dict(res: noderpc.ExecutionResult, idx: int = 0) -> dict:
+    """
+    Convert the stack item at `idx` to a dictionary
+
+    Args:
+        res:
+        idx: idx: the index in the result stack to fetch the stack item from.
+
+    Returns:
+
+    """
+    return item(res, idx).as_dict()
 
 
 def item(res: noderpc.ExecutionResult, idx: int = 0) -> noderpc.StackItem:

--- a/neo3/api/unwrap.py
+++ b/neo3/api/unwrap.py
@@ -1,0 +1,150 @@
+"""
+Helper functions to easily fetch native values from the `ResultStack` returned as response by various RPC methods
+such as invoke_function(), invoke_script(), get_application_log_transaction() and get_application_log_block().
+
+Includes sanity checking
+"""
+from __future__ import annotations
+from neo3.api import noderpc
+from neo3 import vm
+from neo3.core import types, cryptography
+
+
+def check_state_ok(res: noderpc.ExecutionResult):
+    """
+    Check if the execution of the transaction finished in a success state
+
+    Raises:
+        ValueError: if the VM state is not HALT
+
+    """
+    if vm.VMState.from_string(res.state) != vm.VMState.HALT:
+        raise ValueError(f"Transaction execution failed with state {res.state} and err: {res.exception}")
+
+
+def as_bool(res: noderpc.ExecutionResult, idx: int = 0) -> bool:
+    """
+    Convert the stack item at `idx` to a bool
+
+    Args:
+        res:
+        idx: the index in the result stack to fetch the stack item from.
+
+    Raises:
+        ValueError: if the index is out of range, or the value cannot be converted to a bool
+    """
+    return item(res, idx).as_bool()
+
+
+def as_str(res: noderpc.ExecutionResult, idx: int = 0) -> str:
+    """
+    Convert the stack item at `idx` to a str
+
+    Args:
+        res:
+        idx: the index in the result stack to fetch the stack item from.
+
+    Raises:
+        ValueError: if the index is out of range, or the value cannot be converted to a str
+    """
+    return item(res, idx).as_str()
+
+
+def as_int(res: noderpc.ExecutionResult, idx: int = 0) -> int:
+    """
+    Convert the stack item at `idx` to an int
+
+    Args:
+        res:
+        idx: the index in the result stack to fetch the stack item from.
+
+    Raises:
+        ValueError: if the index is out of range, or the value cannot be converted to an int
+    """
+    return item(res, idx).as_int()
+
+
+def as_uint160(res: noderpc.ExecutionResult, idx: int = 0) -> types.UInt160:
+    """
+    Convert the stack item at `idx` to an UInt160
+
+    Args:
+        res:
+        idx: the index in the result stack to fetch the stack item from.
+
+    Raises:
+        ValueError: if the index is out of range, or the value cannot be converted to an UInt160
+    """
+    return item(res, idx).as_uint160()
+
+
+def as_uint256(res: noderpc.ExecutionResult, idx: int = 0) -> types.UInt256:
+    """
+    Convert the stack item at `idx` to an UInt256
+
+    Args:
+        res:
+        idx: the index in the result stack to fetch the stack item from.
+
+    Raises:
+        ValueError: if the index is out of range, or the value cannot be converted to an UInt256
+    """
+
+    return item(res, idx).as_uint256()
+
+
+def as_address(res: noderpc.ExecutionResult, idx: int = 0) -> str:
+    """
+    Convert the stack item at `idx` to a NEO3 address
+
+    Args:
+        res:
+        idx: the index in the result stack to fetch the stack item from.
+
+    Raises:
+        ValueError: if the index is out of range, or the value cannot be converted to a NEO3 address
+    """
+    return item(res, idx).as_address()
+
+
+def as_public_key(res: noderpc.ExecutionResult, idx: int = 0) -> cryptography.ECPoint:
+    """
+    Convert the stack item at `idx` to a public key
+
+    Args:
+        res:
+        idx: the index in the result stack to fetch the stack item from.
+
+    Raises:
+        ValueError: if the index is out of range, or the value cannot be converted to a bool
+        ECCException: if the resulting key is not valid on the SECP256R1 curve
+    """
+    return item(res, idx).as_public_key()
+
+
+def as_list(res: noderpc.ExecutionResult, idx: int = 0) -> list:
+    """
+    Convert the stack item at `idx` to a list
+
+    Args:
+        res:
+        idx: the index in the result stack to fetch the stack item from.
+
+    Raises:
+        ValueError: if the index is out of range, or the value cannot be converted to a bool
+    """
+    return item(res, idx).as_list()
+
+
+def item(res: noderpc.ExecutionResult, idx: int = 0) -> noderpc.StackItem:
+    """
+    Fetch the stack item at `idx` from the result stack. Performs basic validation and bounds checking
+
+    Args:
+        res:
+        idx: the index in the result stack to fetch the stack item from.
+    """
+    check_state_ok(res)
+    if idx > len(res.stack) - 1:
+        raise ValueError("Too few result items")
+    return res.stack[idx]

--- a/neo3/api/wrappers.py
+++ b/neo3/api/wrappers.py
@@ -1,0 +1,401 @@
+"""
+Convenience wrappers for calling smart contracts via RPC.
+
+* The most specific wrappers in this module are for NEOs native contracts
+  * NeoToken, GasToken TODO: add remaining contracts
+* One step up are wrappers for contracts following the NEP-17 Token standard (`NEP17Contract`) and NEP-11 NFT standard
+(`NEP11Contract`)
+* As last resort there is the `GenericContract` which can be used for calling arbitrary functions on arbitrary contracts
+
+Obtaining the results of the functions on the wrapped contracts is done through one of 3 methods
+1. test_invoke() - does not persist to chain. Costs no gas.
+2. invoke() - does persist to chain. Requires signing and costs gas.
+3. estimate_gas - does not persist to chain. Costs no gas.
+
+Example:
+    neo = NeoToken(Config.dummy_config())
+    result = await test_invoke(neo.candidates_registered())
+"""
+
+from __future__ import annotations
+import asyncio
+from typing import Callable, Any, TypeVar, Optional, cast
+from neo3.api import noderpc, unwrap
+from neo3.network.payloads import verification
+from neo3.wallet import account, utils as walletutils
+from neo3.core import types, cryptography, utils as coreutils
+from neo3 import vm
+from neo3.contracts import contract, callflags, utils as contractutils
+
+# Do not call functions returning a ContractMethodFuture directly as you would a real Future.
+# The Future usage is a workaround that allows to forward the annotated return type (ContractFuture[T]) of the
+# annotated function "f" to a consumer function, without having to actually return an instance of T in the
+# implementation of function "f"
+# It has the nice property of failing when used incorrectly as opposed to a solution using
+# class ContractMethodFuture(Generic[T]): pass
+ContractMethodFuture = asyncio.Future
+
+
+# result stack index
+ItemIndex = int
+ExecutionResultParser = Callable[[noderpc.ExecutionResult, ItemIndex], Any]
+
+ReturnType = TypeVar('ReturnType')
+
+_DEFAULT_RPC = "http://seed1.neo.org:10332"
+
+
+class Config:
+    # TODO: describe, organise
+    def __init__(self,
+                 sender: verification.Signer = None,
+                 rpc_host: str = None,
+                 acc: account.Account = None
+                 ):
+        self.sender = sender
+        self.rpc_host = rpc_host
+        self.account = acc
+        self.signers = [sender]
+
+    @classmethod
+    def dummy_config(cls):
+        acc = account.Account.watch_only_from_address("NU7nUXkVLybRA8Bt12dsLtZBrnfuirM57k")
+        sender = verification.Signer(acc.script_hash)
+        c = cls(sender, _DEFAULT_RPC, acc)
+        return c
+
+
+async def test_invoke(f: ContractMethodFuture[ReturnType],
+                      signers: Optional[list[verification.Signer]] = None) -> ReturnType:
+    """
+    Call the contract method in read-only mode
+
+    This does not persist any state on the actual chain and therefore does not require signing or paying GAS.
+
+    See Also: invoke()
+    """
+    # just grabbing the exception to avoid runtime warnings. We're not supposed to call this future
+    f.exception()
+
+    async with noderpc.NeoRpcClient(Config.dummy_config().rpc_host) as client:
+        script = getattr(f, "script", None)
+        if script is None or not isinstance(script, bytes):
+            raise ValueError(f"invalid script: {script}")
+        res = await client.invoke_script(script, signers)
+
+        if (func := getattr(f, "func", None)) is None or not callable(func):
+            return res
+        return func(res)
+
+
+async def invoke(f: ContractMethodFuture[ReturnType],
+                 signers: Optional[list[verification.Signer]] = None) -> types.UInt256:
+    """
+    Call the contract method in write-only mode
+
+    This persists state on the actual chain and costs GAS
+
+    Args:
+        f:
+        signers: override the list of signers
+
+    Returns: transaction id if successful.
+    """
+    pass
+
+
+async def estimate_gas(f: ContractMethodFuture,
+                       signers: Optional[list[verification.Signer]] = None) -> int:
+    """
+    Estimates the gas price for calling the contract method
+    """
+    # just grabbing the exception to avoid runtime warnings as we're not supposed to use the actual future
+    f.exception()
+
+    async with noderpc.NeoRpcClient(Config.dummy_config().rpc_host) as client:
+        script = getattr(f, "script", None)
+        if script is None or not isinstance(script, bytes):
+            raise ValueError(f"invalid script: {script}")
+
+        res = await client.invoke_script(script, signers)
+        return res.gas_consumed
+
+
+def future_contract_method_result(script: bytes,
+                                  func: Optional[ExecutionResultParser] = None) -> ContractMethodFuture:
+    """
+    Utility function to wrap a VM script into a format that can be consumed by testinvoke(), invoke() or estimate_gas()
+
+    Args:
+        script: VM opcodes as outputted by ScriptBuilder
+        func: a function to call for postprocessing the script execution results
+    """
+    loop = asyncio.get_running_loop()
+    fut = loop.create_future()
+    setattr(fut, "script", script)
+    setattr(fut, "func", func)
+    fut.set_exception(ValueError("Do not call directly. Use testinvoke(), invoke() or estimate_gas()"))
+    return cast(ContractMethodFuture, fut)
+
+
+class GenericContract:
+    """
+    Generic class to call arbitrary methods on a smart contract
+    """
+    def __init__(self, contract_hash, config: Config):
+        self.hash = contract_hash
+        self.config = config
+
+    def call_function(self, name, args=None) -> ContractMethodFuture[noderpc.ExecutionResult]:
+        if args is None:
+            script = vm.ScriptBuilder().emit_contract_call(self.hash, name).to_array()
+        else:
+            script = vm.ScriptBuilder().emit_contract_call_with_args(self.hash, name, args).to_array()
+        return future_contract_method_result(script)
+
+
+class NEP17Contract:
+    """
+    Base class for calling NEP-17 compliant smart contracts
+    """
+    def __init__(self, contract_hash: types.UInt160, config: Config):
+        self.hash = contract_hash
+        self.config = config
+
+    def symbol(self) -> ContractMethodFuture[str]:
+        """
+        User-friendly name of the token
+        """
+        script = vm.ScriptBuilder().emit_contract_call(self.hash, "symbol").to_array()
+        return future_contract_method_result(script, unwrap.as_str)
+
+    def decimals(self) -> ContractMethodFuture[int]:
+        """
+        Get the amount of decimals
+
+        Use this with the result of balance_of to display the correct user representation
+        """
+        script = vm.ScriptBuilder().emit_contract_call(self.hash, "decimals").to_array()
+        return future_contract_method_result(script, unwrap.as_int)
+
+    def total_supply(self) -> ContractMethodFuture[int]:
+        """
+        Get the total token supply in the NEO system
+        """
+        script = vm.ScriptBuilder().emit_contract_call(self.hash, "totalSupply").to_array()
+        return future_contract_method_result(script, unwrap.as_int)
+
+    def balance_of(self, account: types.UInt160) -> ContractMethodFuture[int]:
+        """
+        Get the balance for the given account
+
+        Note: the returned value does not take the token decimals into account. e.g. for the GAS token you want to
+        divide the result by 10**8 (as the Gas token has 8 decimals).
+        """
+        script = vm.ScriptBuilder().emit_contract_call_with_args(self.hash, "balanceOf", [account]).to_array()
+        return future_contract_method_result(script, unwrap.as_int)
+
+    def balance_of_friendly(self, account: types.UInt160) -> ContractMethodFuture[float]:
+        """
+        Get the balance for the given account and convert the result into the user representation
+
+        Uses the token decimals to convert to the user end representation
+        """
+        sb = vm.ScriptBuilder()
+        sb.emit_contract_call_with_args(self.hash, "balanceOf", [account])
+        sb.emit_contract_call(self.hash, "decimals")
+
+        def process(res: noderpc.ExecutionResult, _: int) -> float:
+            unwrap.check_state_ok(res)
+            balance = unwrap.as_int(res, 0)
+            decimals = unwrap.as_int(res, 1)
+            if balance == 0:
+                return 0.0
+            else:
+                return balance / (10**decimals)
+        return future_contract_method_result(sb.to_array(), process)
+
+    def transfer(self,
+                 source: types.UInt160,
+                 destination: types.UInt160,
+                 amount: int) -> ContractMethodFuture[bool]:
+        """
+        Transfer `amount` of tokens from `source` account to `destination` account.
+
+        For this to pass while using `testinvoke()`, make sure to add a Signer with a script hash equal to the source
+        account. i.e.
+
+            source = <source_script_hash>
+            signer = verification.Signer(source, payloads.WitnessScope.CALLED_BY_ENTRY)
+            await testinvoke(token.transfer(source, destination, 10), signers=[signer]))
+
+        Returns: True if funds transferred successful. False otherwise.
+        """
+        sb = vm.ScriptBuilder().emit_contract_call_with_args(self.hash, "transfer", [source, destination, amount, None])
+        return future_contract_method_result(sb.to_array(), unwrap.as_bool)
+
+    def transfer_multi(self,
+                       source: types.UInt160,
+                       destinations: list[types.UInt160],
+                       amount: int,
+                       abort_on_failure: bool = False) -> ContractMethodFuture[bool]:
+        """
+        Transfer `amount` of tokens from `source` to each account in `destinations`
+
+        Args:
+            source: account to take funds from
+            destinations: accounts to send funds to
+            amount: how much to transfer
+            abort_on_failure: if True aborts the whole transaction if any of the transfers fails.
+
+        Returns: True if all transfers are successful. False otherwise.
+        """
+        sb = vm.ScriptBuilder()
+        for d in destinations:
+            sb.emit_contract_call_with_args(self.hash, "transfer", [source, d, amount, None])
+            if abort_on_failure:
+                sb.emit(vm.OpCode.ASSERT)
+
+        # when abort_on_failure is used the result of the `transfer()` call is consumed by the ASSERT opcode
+        # and the `stack` will be empty. Therefore, we only check for the VM state
+        def process_with_assert(res: noderpc.ExecutionResult, _: int) -> bool:
+            unwrap.check_state_ok(res)
+            return True
+
+        # when abort_on_failure is not used we iterate over all transfer() results
+        def process(res: noderpc.ExecutionResult, _: int) -> bool:
+            unwrap.check_state_ok(res)
+            for si in res.stack:
+                if si.as_bool() is False:
+                    return False
+            return True
+
+        if abort_on_failure:
+            return future_contract_method_result(sb.to_array(), process_with_assert)
+        else:
+            return future_contract_method_result(sb.to_array(), process)
+
+
+class GasToken(NEP17Contract):
+    def __init__(self, config: Config):
+        super(GasToken, self).__init__(contract.CONTRACT_HASHES.GAS_TOKEN, config)
+
+
+class Candidate:
+    """
+    Container for holding consensus candidate voting results
+    """
+    def __init__(self, public_key: cryptography.ECPoint, votes: int):
+        self.public_key = public_key
+        self.votes = votes
+        shash = coreutils.to_script_hash(contractutils.create_signature_redeemscript(self.public_key))
+        self.address = walletutils.script_hash_to_address(shash)
+
+
+class NeoToken(NEP17Contract):
+    def __init__(self, config: Config):
+        super(NeoToken, self).__init__(contract.CONTRACT_HASHES.NEO_TOKEN, config)
+
+    def get_gas_per_block(self) -> ContractMethodFuture[int]:
+        """
+        Get the amount of GAS generated in each block
+        """
+        script = vm.ScriptBuilder().emit_contract_call(self.hash, "getGasPerBlock").to_array()
+        return future_contract_method_result(script, unwrap.as_int)
+
+    def get_unclaimed_gas(self, account: types.UInt160, end: Optional[int] = None) -> ContractMethodFuture[int]:
+        """
+        Get the amount of unclaimed GAS for `account`
+
+        Args:
+            end: up to which block height to calculate the GAS bonus. Omit to calculate to the current chain height
+        """
+        sb = vm.ScriptBuilder()
+        if end is not None:
+            sb.emit_contract_call_with_args(self.hash, "unclaimedGas", [account, end]).to_array()
+            return future_contract_method_result(sb.to_array(), unwrap.as_int)
+        else:
+            sb.emit_contract_call(contract.CONTRACT_HASHES.LEDGER, "currentIndex")
+            # first argument to "unclaimedGas" (second is already on the stack by the "currentIndex" call
+            sb.emit_push(account)
+            # length of arguments
+            sb.emit_push(2)
+            sb.emit(vm.OpCode.PACK)
+            sb.emit_push(callflags.CallFlags.ALL)
+            sb.emit_push("unclaimedGas")
+            sb.emit_push(self.hash)
+            sb.emit_syscall(vm.Syscalls.SYSTEM_CONTRACT_CALL)
+            return future_contract_method_result(sb.to_array(), unwrap.as_int)
+
+    def candidate_registration_price(self) -> ContractMethodFuture[int]:
+        """
+        Get the amount of GAS to pay to register as consensus candidate
+        """
+        script = vm.ScriptBuilder().emit_contract_call(self.hash, "getRegisterPrice").to_array()
+        return future_contract_method_result(script, unwrap.as_int)
+
+    def candidate_register(self, public_key: cryptography.ECPoint) -> ContractMethodFuture[bool]:
+        """
+        Register as a consensus candidate
+
+        See Also: wallet.Account.public_key
+
+        Returns: True if successful. False otherwise.
+        """
+        sb = vm.ScriptBuilder()
+        sb.emit_contract_call_with_args(self.hash, "registerCandidate", [public_key]).to_array()
+        return future_contract_method_result(sb.to_array(), unwrap.as_bool)
+
+    def candidate_unregister(self, public_key: cryptography.ECPoint) -> ContractMethodFuture[bool]:
+        """
+        Unregister as a consensus candidate
+
+        See Also: wallet.Account.public_key
+
+        Returns: True if successful. False otherwise.
+        """
+        sb = vm.ScriptBuilder()
+        sb.emit_contract_call_with_args(self.hash, "registerCandidate", [public_key]).to_array()
+        return future_contract_method_result(sb.to_array(), unwrap.as_bool)
+
+    def candidate_vote(self, voter: types.UInt160, candidate: cryptography.ECPoint) -> ContractMethodFuture[bool]:
+        """
+        Cast a vote for `candidate` to become a consensus node
+
+        Args:
+            voter: the account to vote from
+            candidate: who to vote on
+
+        Returns: True if vote cast successful. False otherwise.
+        """
+        script = vm.ScriptBuilder().emit_contract_call_with_args(self.hash, "vote", [voter, candidate]).to_array()
+        return future_contract_method_result(script, unwrap.as_bool)
+
+    def candidate_votes(self, candidate: cryptography.ECPoint) -> ContractMethodFuture[int]:
+        """
+        Get the total vote count for `candidate`
+        """
+        script = vm.ScriptBuilder().emit_contract_call_with_args(self.hash, "getCandidateVote", [candidate]).to_array()
+        return future_contract_method_result(script, unwrap.as_int)
+
+    def candidates_registered(self) -> ContractMethodFuture[list[Candidate]]:
+        """
+        Get the first 256 registered candidates
+        Returns:
+
+        """
+        script = vm.ScriptBuilder().emit_contract_call(self.hash, "getCandidates").to_array()
+
+        def process(res: noderpc.ExecutionResult, _: int) -> list[Candidate]:
+            raw_results: list[noderpc.StackItem] = unwrap.as_list(res)
+            result = []
+
+            for si in raw_results:
+                if si.type != "Struct":
+                    continue
+                v = cast(list[noderpc.StackItem], si.value)
+                result.append(Candidate(v[0].as_public_key(), v[1].as_int()))
+            return result
+
+        return future_contract_method_result(script, process)
+

--- a/neo3/api/wrappers.py
+++ b/neo3/api/wrappers.py
@@ -497,12 +497,8 @@ class _NEP11Contract(_TokenContract):
 
         Note: this is an optional method and may not exist on the contract
         """
-        # TODO: NEP-11 states that the return value must conform to "NEO NFT Metadata JSON Schema", but it is unknown
-        # where to find this schema
-
-        # sb = vm.ScriptBuilder().emit_contract_call_with_args(self.hash, "properties", [token_id])
-        # return future_contract_method_result(sb.to_array())
-        raise NotImplementedError
+        sb = vm.ScriptBuilder().emit_contract_call_with_args(self.hash, "properties", [token_id])
+        return future_contract_method_result(sb.to_array(), unwrap.as_dict)
 
 
 class NEP11DivisibleContract(_NEP11Contract):

--- a/neo3/api/wrappers.py
+++ b/neo3/api/wrappers.py
@@ -20,8 +20,7 @@ Example:
 """
 
 from __future__ import annotations
-import asyncio
-from typing import Callable, Any, TypeVar, Optional, cast
+from typing import Callable, Any, TypeVar, Optional, cast, Generic
 from neo3.api import noderpc, unwrap
 from neo3.network.payloads import verification
 from neo3.wallet import account, utils as walletutils
@@ -29,19 +28,39 @@ from neo3.core import types, cryptography, utils as coreutils
 from neo3 import vm
 from neo3.contracts import contract, callflags, utils as contractutils
 
-# Do not call functions returning a ContractMethodFuture directly as you would a real Future.
-# The Future usage is a workaround that allows to forward the annotated return type (ContractFuture[T]) of the
-# annotated function "f" to a consumer function, without having to actually return an instance of T in the
-# implementation of function "f"
-# It has the nice property of failing when used incorrectly as opposed to a solution using
-# class ContractMethodFuture(Generic[T]): pass
-ContractMethodFuture = asyncio.Future
-
 # result stack index
 ItemIndex = int
 ExecutionResultParser = Callable[[noderpc.ExecutionResult, ItemIndex], Any]
 
 ReturnType = TypeVar('ReturnType')
+
+
+class ContractMethodResult(Generic[ReturnType]):
+    """
+    A helper class around the script (VM opcodes) to be executed which allows to forward the annotated return type 
+    (ContractMethodResult[T]) of the annotated function "f" to a consumer function, without having to actually return
+     an instance of T in the implementation of "f".
+
+     Example:
+         def get_name() -> ContractMethodResult[str]:
+            script = vm.ScriptBuilder().emit_contract_call(some_hash, "name")
+            return ContractMethodResult(script, unwrap.as_str)
+
+        def consumer(f: ContractMethodResult[ReturnType]) -> ReturnType:
+            res = rpc.invoke_script(f.script)
+            return f.func(res) # unwraps the result as a string
+
+        x = consumer(get_name())
+        type(x) # str
+    """
+    def __init__(self, script: bytes, func: Optional[ExecutionResultParser] = None):
+        super(ContractMethodResult, self).__init__()
+        self.script = script
+        self.func = func
+
+    def __call__(self, *args, **kwargs):
+        pass
+
 
 _DEFAULT_RPC = "http://seed1.neo.org:10332"
 
@@ -58,7 +77,7 @@ class ChainFacade:
         self._signing_func = None
 
     async def test_invoke(self,
-                          f: ContractMethodFuture[ReturnType],
+                          f: ContractMethodResult[ReturnType],
                           signers: Optional[list[verification.Signer]] = None) -> ReturnType:
         """
         Call the contract method in read-only mode
@@ -70,7 +89,7 @@ class ChainFacade:
         return await self._test_invoke(f, signers)
 
     async def test_invoke_raw(self,
-                              f: ContractMethodFuture[ReturnType],
+                              f: ContractMethodResult[ReturnType],
                               signers: Optional[list[verification.Signer]] = None) -> noderpc.ExecutionResult:
         """
         Call the contract method in read-only mode
@@ -82,7 +101,7 @@ class ChainFacade:
         return await self._test_invoke(f, signers, return_raw=True)
 
     async def _test_invoke(self,
-                           f: ContractMethodFuture[ReturnType],
+                           f: ContractMethodResult[ReturnType],
                            signers: Optional[list[verification.Signer]] = None,
                            return_raw: Optional[bool] = False
                            ):
@@ -93,44 +112,30 @@ class ChainFacade:
 
         See Also: invoke()
         """
-        # just grabbing the exception to avoid runtime warnings. We're not supposed to call this future
-        f.exception()
-
         async with noderpc.NeoRpcClient(self.config.rpc_host) as client:
-            script = getattr(f, "script", None)
-            if script is None or not isinstance(script, bytes):
-                raise ValueError(f"invalid script: {script}")
-            res = await client.invoke_script(script, signers)
-
-            if (func := getattr(f, "func", None)) is None or not callable(func) or return_raw:
+            res = await client.invoke_script(f.script, signers)
+            if f.func is None or return_raw:
                 return res
-            return func(res)
+            return f.func(res, 0)
 
     async def invoke(self,
-                     f: ContractMethodFuture[ReturnType],
+                     f: ContractMethodResult[ReturnType],
                      signers: Optional[list[verification.Signer]] = None) -> types.UInt256:
         raise NotImplementedError
 
     async def invoke_raw(self,
-                         f: ContractMethodFuture[ReturnType],
+                         f: ContractMethodResult[ReturnType],
                          signers: Optional[list[verification.Signer]] = None) -> noderpc.ExecutionResult:
         raise NotImplementedError
 
     async def estimate_gas(self,
-                           f: ContractMethodFuture,
+                           f: ContractMethodResult,
                            signers: Optional[list[verification.Signer]] = None) -> int:
         """
         Estimates the gas price for calling the contract method
         """
-        # just grabbing the exception to avoid runtime warnings as we're not supposed to use the actual future
-        f.exception()
-
         async with noderpc.NeoRpcClient(self.config.rpc_host) as client:
-            script = getattr(f, "script", None)
-            if script is None or not isinstance(script, bytes):
-                raise ValueError(f"invalid script: {script}")
-
-            res = await client.invoke_script(script, signers)
+            res = await client.invoke_script(f.script, signers)
             return res.gas_consumed
 
     @classmethod
@@ -159,23 +164,6 @@ class Config:
         return c
 
 
-def future_contract_method_result(script: bytes,
-                                  func: Optional[ExecutionResultParser] = None) -> ContractMethodFuture:
-    """
-    Utility function to wrap a VM script into a format that can be consumed by test_invoke(), invoke() or estimate_gas()
-
-    Args:
-        script: VM opcodes as outputted by ScriptBuilder
-        func: a function to call for postprocessing the script execution results
-    """
-    loop = asyncio.get_running_loop()
-    fut = loop.create_future()
-    setattr(fut, "script", script)
-    setattr(fut, "func", func)
-    fut.set_exception(ValueError("Do not call directly. Use test_invoke(), invoke() or estimate_gas()"))
-    return cast(ContractMethodFuture, fut)
-
-
 class GenericContract:
     """
     Generic class to call arbitrary methods on a smart contract
@@ -184,12 +172,12 @@ class GenericContract:
     def __init__(self, contract_hash):
         self.hash = contract_hash
 
-    def call_function(self, name, args=None) -> ContractMethodFuture[noderpc.ExecutionResult]:
+    def call_function(self, name, args=None) -> ContractMethodResult[noderpc.ExecutionResult]:
         if args is None:
             script = vm.ScriptBuilder().emit_contract_call(self.hash, name).to_array()
         else:
             script = vm.ScriptBuilder().emit_contract_call_with_args(self.hash, name, args).to_array()
-        return future_contract_method_result(script)
+        return ContractMethodResult(script)
 
 
 class _TokenContract(GenericContract):
@@ -197,28 +185,35 @@ class _TokenContract(GenericContract):
     Base class for Fungible and Non-Fungible tokens
     """
 
-    def symbol(self) -> ContractMethodFuture[str]:
+    def symbol(self) -> ContractMethodResult[str]:
         """
         User-friendly name of the token
         """
         script = vm.ScriptBuilder().emit_contract_call(self.hash, "symbol").to_array()
-        return future_contract_method_result(script, unwrap.as_str)
+        return ContractMethodResult(script, unwrap.as_str)
 
-    def decimals(self) -> ContractMethodFuture[int]:
+    def symbol2(self) -> ContractMethodResult[str]:
+        """
+        User-friendly name of the token
+        """
+        script = vm.ScriptBuilder().emit_contract_call(self.hash, "symbol").to_array()
+        return ContractMethodResult(script, unwrap.as_str)
+
+    def decimals(self) -> ContractMethodResult[int]:
         """
         Get the amount of decimals
 
         Use this with the result of balance_of to display the correct user representation
         """
         script = vm.ScriptBuilder().emit_contract_call(self.hash, "decimals").to_array()
-        return future_contract_method_result(script, unwrap.as_int)
+        return ContractMethodResult(script, unwrap.as_int)
 
-    def total_supply(self) -> ContractMethodFuture[int]:
+    def total_supply(self) -> ContractMethodResult[int]:
         """
         Get the total token supply in the NEO system
         """
         script = vm.ScriptBuilder().emit_contract_call(self.hash, "totalSupply").to_array()
-        return future_contract_method_result(script, unwrap.as_int)
+        return ContractMethodResult(script, unwrap.as_int)
 
 
 class NEP17Contract(_TokenContract):
@@ -226,7 +221,7 @@ class NEP17Contract(_TokenContract):
     Base class for calling NEP-17 compliant smart contracts
     """
 
-    def balance_of(self, account: types.UInt160) -> ContractMethodFuture[int]:
+    def balance_of(self, account: types.UInt160) -> ContractMethodResult[int]:
         """
         Get the balance for the given account
 
@@ -234,9 +229,9 @@ class NEP17Contract(_TokenContract):
         divide the result by 10**8 (as the Gas token has 8 decimals).
         """
         script = vm.ScriptBuilder().emit_contract_call_with_args(self.hash, "balanceOf", [account]).to_array()
-        return future_contract_method_result(script, unwrap.as_int)
+        return ContractMethodResult(script, unwrap.as_int)
 
-    def balance_of_friendly(self, account: types.UInt160) -> ContractMethodFuture[float]:
+    def balance_of_friendly(self, account: types.UInt160) -> ContractMethodResult[float]:
         """
         Get the balance for the given account and convert the result into the user representation
 
@@ -255,12 +250,12 @@ class NEP17Contract(_TokenContract):
             else:
                 return balance / (10 ** decimals)
 
-        return future_contract_method_result(sb.to_array(), process)
+        return ContractMethodResult(sb.to_array(), process)
 
     def transfer(self,
                  source: types.UInt160,
                  destination: types.UInt160,
-                 amount: int) -> ContractMethodFuture[bool]:
+                 amount: int) -> ContractMethodResult[bool]:
         """
         Transfer `amount` of tokens from `source` account to `destination` account.
 
@@ -274,13 +269,13 @@ class NEP17Contract(_TokenContract):
         Returns: True if funds transferred successful. False otherwise.
         """
         sb = vm.ScriptBuilder().emit_contract_call_with_args(self.hash, "transfer", [source, destination, amount, None])
-        return future_contract_method_result(sb.to_array(), unwrap.as_bool)
+        return ContractMethodResult(sb.to_array(), unwrap.as_bool)
 
     def transfer_multi(self,
                        source: types.UInt160,
                        destinations: list[types.UInt160],
                        amount: int,
-                       abort_on_failure: bool = False) -> ContractMethodFuture[bool]:
+                       abort_on_failure: bool = False) -> ContractMethodResult[bool]:
         """
         Transfer `amount` of tokens from `source` to each account in `destinations`
 
@@ -313,9 +308,9 @@ class NEP17Contract(_TokenContract):
             return True
 
         if abort_on_failure:
-            return future_contract_method_result(sb.to_array(), process_with_assert)
+            return ContractMethodResult(sb.to_array(), process_with_assert)
         else:
-            return future_contract_method_result(sb.to_array(), process)
+            return ContractMethodResult(sb.to_array(), process)
 
 
 class GasToken(NEP17Contract):
@@ -339,14 +334,14 @@ class NeoToken(NEP17Contract):
     def __init__(self):
         super(NeoToken, self).__init__(contract.CONTRACT_HASHES.NEO_TOKEN)
 
-    def get_gas_per_block(self) -> ContractMethodFuture[int]:
+    def get_gas_per_block(self) -> ContractMethodResult[int]:
         """
         Get the amount of GAS generated in each block
         """
         script = vm.ScriptBuilder().emit_contract_call(self.hash, "getGasPerBlock").to_array()
-        return future_contract_method_result(script, unwrap.as_int)
+        return ContractMethodResult(script, unwrap.as_int)
 
-    def get_unclaimed_gas(self, account: types.UInt160, end: Optional[int] = None) -> ContractMethodFuture[int]:
+    def get_unclaimed_gas(self, account: types.UInt160, end: Optional[int] = None) -> ContractMethodResult[int]:
         """
         Get the amount of unclaimed GAS for `account`
 
@@ -356,7 +351,7 @@ class NeoToken(NEP17Contract):
         sb = vm.ScriptBuilder()
         if end is not None:
             sb.emit_contract_call_with_args(self.hash, "unclaimedGas", [account, end]).to_array()
-            return future_contract_method_result(sb.to_array(), unwrap.as_int)
+            return ContractMethodResult(sb.to_array(), unwrap.as_int)
         else:
             sb.emit_contract_call(contract.CONTRACT_HASHES.LEDGER, "currentIndex")
             # first argument to "unclaimedGas" (second is already on the stack by the "currentIndex" call
@@ -368,16 +363,16 @@ class NeoToken(NEP17Contract):
             sb.emit_push("unclaimedGas")
             sb.emit_push(self.hash)
             sb.emit_syscall(vm.Syscalls.SYSTEM_CONTRACT_CALL)
-            return future_contract_method_result(sb.to_array(), unwrap.as_int)
+            return ContractMethodResult(sb.to_array(), unwrap.as_int)
 
-    def candidate_registration_price(self) -> ContractMethodFuture[int]:
+    def candidate_registration_price(self) -> ContractMethodResult[int]:
         """
         Get the amount of GAS to pay to register as consensus candidate
         """
         script = vm.ScriptBuilder().emit_contract_call(self.hash, "getRegisterPrice").to_array()
-        return future_contract_method_result(script, unwrap.as_int)
+        return ContractMethodResult(script, unwrap.as_int)
 
-    def candidate_register(self, public_key: cryptography.ECPoint) -> ContractMethodFuture[bool]:
+    def candidate_register(self, public_key: cryptography.ECPoint) -> ContractMethodResult[bool]:
         """
         Register as a consensus candidate
 
@@ -387,9 +382,9 @@ class NeoToken(NEP17Contract):
         """
         sb = vm.ScriptBuilder()
         sb.emit_contract_call_with_args(self.hash, "registerCandidate", [public_key]).to_array()
-        return future_contract_method_result(sb.to_array(), unwrap.as_bool)
+        return ContractMethodResult(sb.to_array(), unwrap.as_bool)
 
-    def candidate_unregister(self, public_key: cryptography.ECPoint) -> ContractMethodFuture[bool]:
+    def candidate_unregister(self, public_key: cryptography.ECPoint) -> ContractMethodResult[bool]:
         """
         Unregister as a consensus candidate
 
@@ -399,9 +394,9 @@ class NeoToken(NEP17Contract):
         """
         sb = vm.ScriptBuilder()
         sb.emit_contract_call_with_args(self.hash, "registerCandidate", [public_key]).to_array()
-        return future_contract_method_result(sb.to_array(), unwrap.as_bool)
+        return ContractMethodResult(sb.to_array(), unwrap.as_bool)
 
-    def candidate_vote(self, voter: types.UInt160, candidate: cryptography.ECPoint) -> ContractMethodFuture[bool]:
+    def candidate_vote(self, voter: types.UInt160, candidate: cryptography.ECPoint) -> ContractMethodResult[bool]:
         """
         Cast a vote for `candidate` to become a consensus node
 
@@ -412,16 +407,16 @@ class NeoToken(NEP17Contract):
         Returns: True if vote cast successful. False otherwise.
         """
         script = vm.ScriptBuilder().emit_contract_call_with_args(self.hash, "vote", [voter, candidate]).to_array()
-        return future_contract_method_result(script, unwrap.as_bool)
+        return ContractMethodResult(script, unwrap.as_bool)
 
-    def candidate_votes(self, candidate: cryptography.ECPoint) -> ContractMethodFuture[int]:
+    def candidate_votes(self, candidate: cryptography.ECPoint) -> ContractMethodResult[int]:
         """
         Get the total vote count for `candidate`
         """
         script = vm.ScriptBuilder().emit_contract_call_with_args(self.hash, "getCandidateVote", [candidate]).to_array()
-        return future_contract_method_result(script, unwrap.as_int)
+        return ContractMethodResult(script, unwrap.as_int)
 
-    def candidates_registered(self) -> ContractMethodFuture[list[Candidate]]:
+    def candidates_registered(self) -> ContractMethodResult[list[Candidate]]:
         """
         Get the first 256 registered candidates
         Returns:
@@ -440,7 +435,7 @@ class NeoToken(NEP17Contract):
                 result.append(Candidate(v[0].as_public_key(), v[1].as_int()))
             return result
 
-        return future_contract_method_result(script, process)
+        return ContractMethodResult(script, process)
 
 
 class _NEP11Contract(_TokenContract):
@@ -449,7 +444,7 @@ class _NEP11Contract(_TokenContract):
 
     NFTs can be divisible or non-divisible which is determined by the value of `decimals()`
     """
-    def decimals(self) -> ContractMethodFuture[int]:
+    def decimals(self) -> ContractMethodResult[int]:
         """
         Get the amount of decimals
 
@@ -458,14 +453,14 @@ class _NEP11Contract(_TokenContract):
         """
         return super(_NEP11Contract, self).decimals()
 
-    def total_owned_by(self, owner: types.UInt160) -> ContractMethodFuture[int]:
+    def total_owned_by(self, owner: types.UInt160) -> ContractMethodResult[int]:
         """
         Get the total amount of NFTs owned for the given account.
         """
         script = vm.ScriptBuilder().emit_contract_call_with_args(self.hash, "balanceOf", [owner]).to_array()
-        return future_contract_method_result(script, unwrap.as_int)
+        return ContractMethodResult(script, unwrap.as_int)
 
-    def token_ids_owned_by(self, owner: types.UInt160) -> ContractMethodFuture[list[bytes]]:
+    def token_ids_owned_by(self, owner: types.UInt160) -> ContractMethodResult[list[bytes]]:
         """
         Get an iterator containing all token ids owned by the specified address
         """
@@ -476,9 +471,9 @@ class _NEP11Contract(_TokenContract):
             raw_results: list[noderpc.StackItem] = unwrap.as_list(res)
             return [si.value for si in raw_results]
 
-        return future_contract_method_result(sb.to_array(), process)
+        return ContractMethodResult(sb.to_array(), process)
 
-    def tokens(self) -> ContractMethodFuture[list[bytes]]:
+    def tokens(self) -> ContractMethodResult[list[bytes]]:
         """
         Get all tokens minted by the contract
 
@@ -489,16 +484,16 @@ class _NEP11Contract(_TokenContract):
             return [si.value for si in raw_results]
 
         sb = vm.ScriptBuilder().emit_contract_call_and_unwrap_iterator(self.hash, "tokens")
-        return future_contract_method_result(sb.to_array(), process)
+        return ContractMethodResult(sb.to_array(), process)
 
-    def properties(self, token_id: bytes) -> ContractMethodFuture[dict]:
+    def properties(self, token_id: bytes) -> ContractMethodResult[dict]:
         """
         Get all properties for the given NFT
 
         Note: this is an optional method and may not exist on the contract
         """
         sb = vm.ScriptBuilder().emit_contract_call_with_args(self.hash, "properties", [token_id])
-        return future_contract_method_result(sb.to_array(), unwrap.as_dict)
+        return ContractMethodResult(sb.to_array(), unwrap.as_dict)
 
 
 class NEP11DivisibleContract(_NEP11Contract):
@@ -508,12 +503,12 @@ class NEP11DivisibleContract(_NEP11Contract):
                  destination: types.UInt160,
                  amount: int,
                  token_id: bytes,
-                 data: Optional[list] = None) -> ContractMethodFuture[bool]:
+                 data: Optional[list] = None) -> ContractMethodResult[bool]:
         sb = vm.ScriptBuilder()
         sb.emit_contract_call_with_args(self.hash, "transfer", [source, destination, amount, token_id, data])
-        return future_contract_method_result(sb.to_array(), unwrap.as_bool)
+        return ContractMethodResult(sb.to_array(), unwrap.as_bool)
 
-    def owners_of(self, token_id: bytes) -> ContractMethodFuture[list[types.UInt160]]:
+    def owners_of(self, token_id: bytes) -> ContractMethodResult[list[types.UInt160]]:
         """
         Get a list of account script hashes that own a part of `token_id`
         """
@@ -524,16 +519,16 @@ class NEP11DivisibleContract(_NEP11Contract):
             raw_results: list[noderpc.StackItem] = unwrap.as_list(res)
             return [si.as_uint160() for si in raw_results]
 
-        return future_contract_method_result(sb.to_array(), process)
+        return ContractMethodResult(sb.to_array(), process)
 
-    def balance_of(self, owner: types.UInt160, token_id: bytes) -> ContractMethodFuture[int]:
+    def balance_of(self, owner: types.UInt160, token_id: bytes) -> ContractMethodResult[int]:
         """
         Get the token balance for the given owner
         """
         sb = vm.ScriptBuilder().emit_contract_call_with_args(self.hash, "balanceOf", [owner, token_id])
-        return future_contract_method_result(sb.to_array(), unwrap.as_int)
+        return ContractMethodResult(sb.to_array(), unwrap.as_int)
 
-    def balance_of_friendly(self, owner: types.UInt160, token_id: bytes) -> ContractMethodFuture[float]:
+    def balance_of_friendly(self, owner: types.UInt160, token_id: bytes) -> ContractMethodResult[float]:
         """
         Get the balance for the given account and convert the result into the user representation
 
@@ -552,7 +547,7 @@ class NEP11DivisibleContract(_NEP11Contract):
             else:
                 return balance / (10 ** decimals)
 
-        return future_contract_method_result(sb.to_array(), process)
+        return ContractMethodResult(sb.to_array(), process)
 
 
 class NEP11NonDivisibleContract(_NEP11Contract):
@@ -560,13 +555,13 @@ class NEP11NonDivisibleContract(_NEP11Contract):
     def transfer(self,
                  destination: types.UInt160,
                  token_id: str,
-                 data: Optional[list] = None) -> ContractMethodFuture[bool]:
+                 data: Optional[list] = None) -> ContractMethodResult[bool]:
         sb = vm.ScriptBuilder().emit_contract_call_with_args(self.hash, "transfer", [destination, token_id, data])
-        return future_contract_method_result(sb.to_array(), unwrap.as_bool)
+        return ContractMethodResult(sb.to_array(), unwrap.as_bool)
 
-    def owner_of(self, token_id: bytes) -> ContractMethodFuture[types.UInt160]:
+    def owner_of(self, token_id: bytes) -> ContractMethodResult[types.UInt160]:
         """
         Get the owner of the given token
         """
         sb = vm.ScriptBuilder().emit_contract_call_with_args(self.hash, "ownerOf", [token_id])
-        return future_contract_method_result(sb.to_array(), unwrap.as_uint160)
+        return ContractMethodResult(sb.to_array(), unwrap.as_uint160)

--- a/neo3/api/wrappers.py
+++ b/neo3/api/wrappers.py
@@ -157,9 +157,9 @@ class GenericContract:
         return future_contract_method_result(script)
 
 
-class NEP17Contract:
+class TokenContract:
     """
-    Base class for calling NEP-17 compliant smart contracts
+    Base class for Fungible and Non-Fungible tokens
     """
     def __init__(self, contract_hash: types.UInt160):
         self.hash = contract_hash
@@ -187,6 +187,11 @@ class NEP17Contract:
         script = vm.ScriptBuilder().emit_contract_call(self.hash, "totalSupply").to_array()
         return future_contract_method_result(script, unwrap.as_int)
 
+
+class NEP17Contract(TokenContract):
+    """
+    Base class for calling NEP-17 compliant smart contracts
+    """
     def balance_of(self, account: types.UInt160) -> ContractMethodFuture[int]:
         """
         Get the balance for the given account

--- a/neo3/api/wrappers.py
+++ b/neo3/api/wrappers.py
@@ -192,13 +192,10 @@ class GenericContract:
         return future_contract_method_result(script)
 
 
-class TokenContract:
+class _TokenContract(GenericContract):
     """
     Base class for Fungible and Non-Fungible tokens
     """
-
-    def __init__(self, contract_hash: types.UInt160):
-        self.hash = contract_hash
 
     def symbol(self) -> ContractMethodFuture[str]:
         """
@@ -224,7 +221,7 @@ class TokenContract:
         return future_contract_method_result(script, unwrap.as_int)
 
 
-class NEP17Contract(TokenContract):
+class NEP17Contract(_TokenContract):
     """
     Base class for calling NEP-17 compliant smart contracts
     """
@@ -446,7 +443,7 @@ class NeoToken(NEP17Contract):
         return future_contract_method_result(script, process)
 
 
-class NEP11Contract(TokenContract):
+class _NEP11Contract(_TokenContract):
     """
     Base class for calling NEP-11 compliant smart contracts
 
@@ -459,7 +456,7 @@ class NEP11Contract(TokenContract):
         A zero return value indicates a non-divisible NFT.
         A bigger than zero return value indicates a divisible NFTs.
         """
-        return super(NEP11Contract, self).decimals()
+        return super(_NEP11Contract, self).decimals()
 
     def total_owned_by(self, owner: types.UInt160) -> ContractMethodFuture[int]:
         """
@@ -508,7 +505,7 @@ class NEP11Contract(TokenContract):
         raise NotImplementedError
 
 
-class NEP11DivisibleContract(NEP11Contract):
+class NEP11DivisibleContract(_NEP11Contract):
     """Base class for divisible NFTs"""
     def transfer(self,
                  source: types.UInt160,
@@ -538,7 +535,7 @@ class NEP11DivisibleContract(NEP11Contract):
         return future_contract_method_result(sb.to_array(), unwrap.as_int)
 
 
-class NEP11NonDivisibleContract(NEP11Contract):
+class NEP11NonDivisibleContract(_NEP11Contract):
     """Base class for non-divisible NFTs"""
     def transfer(self,
                  destination: types.UInt160,

--- a/neo3/api/wrappers.py
+++ b/neo3/api/wrappers.py
@@ -491,7 +491,7 @@ class _NEP11Contract(_TokenContract):
         sb = vm.ScriptBuilder().emit_contract_call_and_unwrap_iterator(self.hash, "tokens")
         return future_contract_method_result(sb.to_array(), process)
 
-    def properties(self, token_id: bytes):
+    def properties(self, token_id: bytes) -> ContractMethodFuture[dict]:
         """
         Get all properties for the given NFT
 

--- a/neo3/api/wrappers.py
+++ b/neo3/api/wrappers.py
@@ -192,13 +192,6 @@ class _TokenContract(GenericContract):
         script = vm.ScriptBuilder().emit_contract_call(self.hash, "symbol").to_array()
         return ContractMethodResult(script, unwrap.as_str)
 
-    def symbol2(self) -> ContractMethodResult[str]:
-        """
-        User-friendly name of the token
-        """
-        script = vm.ScriptBuilder().emit_contract_call(self.hash, "symbol").to_array()
-        return ContractMethodResult(script, unwrap.as_str)
-
     def decimals(self) -> ContractMethodResult[int]:
         """
         Get the amount of decimals


### PR DESCRIPTION
fix #149

This PR is about adding the base code for calling smart contracts conveniently over RPC. From the docstrings of the `wrappers` module

```
Convenience wrappers for calling smart contracts via RPC.
* The most specific wrappers in this module are for NEOs native contracts
  * NeoToken, GasToken TODO: add remaining contracts
* One step up are wrappers for contracts following the NEP-17 Token standard (`NEP17Contract`) and NEP-11 NFT standard
(`NEP11Contract`)
* As last resort there is the `GenericContract` which can be used for calling arbitrary functions on arbitrary contracts

Obtaining the results of the functions on the wrapped contracts is done through one of 3 methods
1. test_invoke() - does not persist to chain. Costs no gas.
2. invoke() - does persist to chain. Requires signing and costs gas.
3. estimate_gas - does not persist to chain. Costs no gas.
```

### Current state

* ~~The `NEP11Contract` generic contract is not yet implemented.~~
* `invoke()` is not yet implemented
* The `Config` isn't thought out yet. Just contains some minimal stuff now

### Feedback
This is a work in progress. I'm looking for feedback on the API in terms of
* is easy is it to use it (considering there is not yet any documentation other than inline)?
* how pythonic does it feel?
* what do you like/dislike about how it works?
* what can be improved?

### Example usage

Here are 3 examples to get your started

-edit- code changed. New example code can be found in this comment https://github.com/CityOfZion/neo-mamba/pull/184#issuecomment-1265176954