### PR TITLE
vm: add support for pushing native lists in ScriptBuilder, fix emit_jump

### DIFF
--- a/neo3/network/payloads/consensus.py
+++ b/neo3/network/payloads/consensus.py
@@ -46,7 +46,7 @@ class ConsensusMessage(serialization.ISerializable):
         self.type = ConsensusMessageType(reader.read_uint8())
         self.view_number = reader.read_uint8()
 
-    def deserialize_specialization_from_bytes(self, data: bytearray) -> ConsensusMessage_t:
+    def deserialize_specialization_from_bytes(self, data: bytearray) -> ConsensusMessage:
         # TODO: not implemented. Requires all ConsensusMessage subclasses to be implemented. Low priority.
         pass
 

--- a/neo3/vm.py
+++ b/neo3/vm.py
@@ -318,6 +318,13 @@ class ScriptBuilder:
                 self.emit_raw(len_value.to_bytes(4, "little"))
                 self.emit_raw(value)
             return self
+        elif isinstance(value, list):
+            self.emit(OpCode.NEWARRAY0)
+            for v in value:
+                self.emit(OpCode.DUP)
+                self.emit_push(v)
+                self.emit(OpCode.APPEND)
+            return self
         else:
             raise ValueError(f"Unsupported value type {type(value)}")
 
@@ -334,9 +341,9 @@ class ScriptBuilder:
             opcode = OpCode(opcode + 1)
 
         if opcode % 2 == 0:
-            return self.emit(opcode, offset.to_bytes(1, "little"))
+            return self.emit(opcode, offset.to_bytes(1, "little", signed=True))
         else:
-            return self.emit(opcode, offset.to_bytes(4, "little"))
+            return self.emit(opcode, offset.to_bytes(4, "little", signed=True))
 
     def emit_call(self, offset: int) -> ScriptBuilder:
         if offset < -128 or offset > 127:


### PR DESCRIPTION
* emit_jump must be able to jump backwards, thus requiring a signed offset
* add support for pushing a native list (this allows i.e. supplying `[something, else]` to the `data` argument of `transfer()` and have it automatically be converted to an `Array` stackitem