### PR TITLE
wallet: fix sign_tx

### DIFF
--- a/neo3/wallet/account.py
+++ b/neo3/wallet/account.py
@@ -252,7 +252,7 @@ class Account:
 
         invocation_script = vm.ScriptBuilder().emit_push(signature).to_array()
         # mypy can't infer that the is_watchonly check ensures public_key has a value
-        verification_script = contracts.Contract.create_signature_redeemscript(self.public_key)  # type: ignore
+        verification_script = contractutils.create_signature_redeemscript(self.public_key)  # type: ignore
         tx.witnesses.insert(0, verification.Witness(invocation_script, verification_script))
 
     def sign_multisig_tx(self,


### PR DESCRIPTION
#183 refactored the project structure and the line in this PR wasn't updated. It did not fail the type check because it was explicitely ignored for other reasons (see the comment above).