### PR TITLE
contracts: fix parsing of multiple callflags

### DIFF
--- a/neo3/contracts/callflags.py
+++ b/neo3/contracts/callflags.py
@@ -16,21 +16,29 @@ class CallFlags(IntFlag):
 
     @classmethod
     def from_csharp_name(cls, input: str):
-        if input == "None":
-            return CallFlags.NONE
-        elif input == "ReadStates":
-            return CallFlags.READ_STATES
-        elif input == "WriteStates":
-            return CallFlags.WRITE_STATES
-        elif input == "AllowCall":
-            return CallFlags.ALLOW_CALL
-        elif input == "AllowNotify":
-            return CallFlags.ALLOW_NOTIFY
-        elif input == "States":
-            return CallFlags.STATES
-        elif input == "ReadOnly":
-            return CallFlags.READ_ONLY
-        elif input == "All":
-            return CallFlags.ALL
-        else:
-            raise ValueError(f"{input} is not a valid member of {cls.__name__}")
+        def get(input):
+            if input == "None":
+                return CallFlags.NONE
+            elif input == "ReadStates":
+                return CallFlags.READ_STATES
+            elif input == "WriteStates":
+                return CallFlags.WRITE_STATES
+            elif input == "AllowCall":
+                return CallFlags.ALLOW_CALL
+            elif input == "AllowNotify":
+                return CallFlags.ALLOW_NOTIFY
+            elif input == "States":
+                return CallFlags.STATES
+            elif input == "ReadOnly":
+                return CallFlags.READ_ONLY
+            elif input == "All":
+                return CallFlags.ALL
+            else:
+                raise ValueError(f"{input} is not a valid member of {cls.__name__}")
+
+        flags = [get(flag.strip()) for flag in input.split(",")]
+
+        result = flags[0]
+        for flag in flags[1:]:
+            result |= flag
+        return result

--- a/tests/contracts/test_callflags.py
+++ b/tests/contracts/test_callflags.py
@@ -1,0 +1,31 @@
+import unittest
+from neo3.contracts.callflags import CallFlags
+
+
+class CallFlagsTestCase(unittest.TestCase):
+    def test_parsing_from_string(self):
+        tests = [
+            ("None", CallFlags.NONE),
+            ("ReadStates", CallFlags.READ_STATES),
+            ("WriteStates", CallFlags.WRITE_STATES),
+            ("AllowCall", CallFlags.ALLOW_CALL),
+            ("AllowNotify", CallFlags.ALLOW_NOTIFY),
+            ("States", CallFlags.STATES),
+            ("ReadOnly", CallFlags.READ_ONLY),
+            ("All", CallFlags.ALL)
+         ]
+        for input, expected in tests:
+            self.assertEqual(expected, CallFlags.from_csharp_name(input))
+
+    def test_parsing_invalid_input(self):
+        with self.assertRaises(ValueError) as context:
+            CallFlags.from_csharp_name("bla")
+        self.assertEqual("bla is not a valid member of CallFlags", str(context.exception))
+
+    def test_parsing_from_string_with_multiple_flags(self):
+        input = "ReadStates, AllowCall"
+        cf = CallFlags.from_csharp_name(input)
+        expected = CallFlags.READ_STATES | CallFlags.ALLOW_CALL
+        self.assertNotEqual(CallFlags.READ_STATES, cf)
+        self.assertNotEqual(CallFlags.ALLOW_CALL, cf)
+        self.assertEqual(expected, cf)


### PR DESCRIPTION
The current parsing can't handle actual flag combinations, just single flags. This solves that