### PR TITLE
api, wallet: add NeoAddress type alias, also support NeoAddress

### DIFF
--- a/neo3/wallet/account.py
+++ b/neo3/wallet/account.py
@@ -11,6 +11,7 @@ from neo3.contracts import abi, utils as contractutils, contract
 from neo3.network.payloads import transaction, verification
 from neo3.core import types, utils as coreutils, cryptography
 from neo3.wallet import utils, scrypt_parameters as scrypt
+from neo3.wallet.types import NeoAddress
 
 # both constants below are used to encrypt/decrypt a private key to/from a nep2 key
 NEP_HEADER = bytes([0x01, 0x42])
@@ -150,7 +151,7 @@ class Account:
         password: str,
         private_key: Optional[bytes] = None,
         watch_only: bool = False,
-        address: Optional[str] = None,
+        address: Optional[NeoAddress] = None,
         label: Optional[str] = None,
         lock: bool = False,
         contract_: Optional[contract.Contract] = None,
@@ -190,7 +191,7 @@ class Account:
             public_key = key_pair.public_key
 
         self.label: Optional[str] = label
-        self.address: str = address
+        self.address: NeoAddress = address
         self.public_key = public_key
         self.encrypted_key = encrypted_key
         self.lock = lock
@@ -471,7 +472,7 @@ class Account:
         )
 
     @classmethod
-    def watch_only_from_address(cls, address: str) -> Account:
+    def watch_only_from_address(cls, address: NeoAddress) -> Account:
         """
         Instantiate and returns a watch-only account from a given address.
 

--- a/neo3/wallet/types.py
+++ b/neo3/wallet/types.py
@@ -1,0 +1,7 @@
+from typing import TypeAlias
+
+# Note that a NeoAddress is just a base58check encoded (address version + script hash).
+# * The address version is a fixed value since the inception of the chain.
+# * The script hash is the public key of an account (ECPair) wrapped with some extra data and hashed
+#   with ripemd160. It is represented in the code with the UInt160 type from the `core` package
+NeoAddress: TypeAlias = str

--- a/neo3/wallet/utils.py
+++ b/neo3/wallet/utils.py
@@ -1,10 +1,11 @@
 import base58
 from neo3.core import types
+from neo3.wallet.types import NeoAddress
 
 
 def script_hash_to_address(
     script_hash: types.UInt160, address_version: int = 0x35
-) -> str:
+) -> NeoAddress:
     """
     Converts the specified script hash to an address.
 
@@ -17,7 +18,7 @@ def script_hash_to_address(
     return base58.b58encode_check(data).decode("utf-8")
 
 
-def address_to_script_hash(address: str) -> types.UInt160:
+def address_to_script_hash(address: NeoAddress) -> types.UInt160:
     """
     Converts the specified address to a script hash.
 
@@ -33,7 +34,7 @@ def address_to_script_hash(address: str) -> types.UInt160:
     return types.UInt160(data[1:])
 
 
-def is_valid_address(address: str) -> bool:
+def is_valid_address(address: NeoAddress) -> bool:
     """
     Test if the provided address is a valid address.
 
@@ -47,7 +48,7 @@ def is_valid_address(address: str) -> bool:
     return True
 
 
-def validate_address(address: str, address_version: int = 0x35) -> None:
+def validate_address(address: NeoAddress, address_version: int = 0x35) -> None:
     """
     Validate a given address. If address is not valid an exception will be raised.
 


### PR DESCRIPTION
... as argument where account script hash is used

based on https://github.com/CityOfZion/neo-mamba/pull/184#issuecomment-1254627717
some internal discussion and feedback in the PR linked suggests users like also being able to supply an address. 

As regarding the implementation; an alternative proposed by Ricardo is to have `UInt160.from_string`  accept not just the `0xsomehash157a4f61fe446e852575327e` format but also try to parse a NEO address. This sounds nice but has some issues in terms of code structure

* considering the project structure below. The bottom layers may never call upwards
![image](https://user-images.githubusercontent.com/6625537/195052694-89d6aa24-1c3d-4b41-83b8-e0bb8f792e7b.png)

    `UInt160`  is part of `CORE` , but `is_valid_address`  is part of `wallet` . `Core` is not allowed to call upwards. This would mean it has to duplicate code
* By duplicating the `is_valid_address` logic we're exceeding the responsibility/purpose of the `UInt160`  type