### PR TITLE
api: use signers from config with test_invoke*

### DIFF
--- a/neo3/api/wrappers.py
+++ b/neo3/api/wrappers.py
@@ -136,9 +136,9 @@ class ChainFacade:
 
         See Also: invoke() - persists state
         """
-        if signers is not None:
-            return await self._test_invoke(f, signers=signers)
-        return await self._test_invoke(f, signers=self.config.signers)
+        if signers is None:
+            signers = self.config.signers
+        return await self._test_invoke(f, signers=signers)
 
     async def test_invoke_multi(
         self,
@@ -155,6 +155,8 @@ class ChainFacade:
 
         See Also: invoke_multi() - persists state
         """
+        if signers is None:
+            signers = self.config.signers
         return await asyncio.gather(
             *map(lambda c: self.test_invoke(c, signers=signers), f)
         )
@@ -177,6 +179,8 @@ class ChainFacade:
 
         See Also: invoke_raw() - persists state
         """
+        if signers is None:
+            signers = self.config.signers
         return await self._test_invoke(f, signers=signers, return_raw=True)
 
     async def _test_invoke(

--- a/neo3/api/wrappers.py
+++ b/neo3/api/wrappers.py
@@ -136,7 +136,9 @@ class ChainFacade:
 
         See Also: invoke() - persists state
         """
-        return await self._test_invoke(f, signers=signers)
+        if signers is not None:
+            return await self._test_invoke(f, signers=signers)
+        return await self._test_invoke(f, signers=self.config.signers)
 
     async def test_invoke_multi(
         self,


### PR DESCRIPTION
`config.add_signer` calls where ignored when using `test_invoke*` without manually overriding the signers