### PR TITLE
api: fix transfer_multi for NeoAddress, raise exception in TxBuilder

### DIFF
--- a/neo3/api/helpers/txbuilder.py
+++ b/neo3/api/helpers/txbuilder.py
@@ -32,7 +32,7 @@ class TxBuilder:
             )
         res = await self.client.invoke_script(self.tx.script, self.tx.signers)
         if res.state != "HALT":
-            print(f"Failed to get system fee: {res.exception}")
+            raise ValueError(f"Failed to get system fee: {res.exception}")
         self.tx.system_fee = res.gas_consumed
 
     async def set_valid_until_block(self):

--- a/neo3/api/wrappers.py
+++ b/neo3/api/wrappers.py
@@ -598,6 +598,7 @@ class NEP17Contract(_TokenContract):
         Returns: True if all transfers are successful. False otherwise.
         """
         sb = vm.ScriptBuilder()
+        source = _check_address_and_convert(source)
         for d in destinations:
             d = _check_address_and_convert(d)
             sb.emit_contract_call_with_args(


### PR DESCRIPTION
* `Nep17Contract.transfer_multi()` only converted the destination address list if supplied as `NeoAddress`, but did not check if the `source` was supplied as a `NeoAddress` 
* raise exception in TxBuilder on fee calculation error