### PR TITLE
api: add contract deploy, update, destroy

### DIFF
--- a/neo3/api/helpers/unwrap.py
+++ b/neo3/api/helpers/unwrap.py
@@ -91,7 +91,6 @@ def as_uint256(res: noderpc.ExecutionResult, idx: int = 0) -> types.UInt256:
     Raises:
         ValueError: if the index is out of range, or the value cannot be converted to an UInt256
     """
-
     return item(res, idx).as_uint256()
 
 
@@ -124,7 +123,7 @@ def as_public_key(res: noderpc.ExecutionResult, idx: int = 0) -> cryptography.EC
     return item(res, idx).as_public_key()
 
 
-def as_list(res: noderpc.ExecutionResult, idx: int = 0) -> list:
+def as_list(res: noderpc.ExecutionResult, idx: int = 0) -> list[noderpc.StackItem]:
     """
     Convert the stack item at `idx` to a list
 
@@ -150,6 +149,20 @@ def as_dict(res: noderpc.ExecutionResult, idx: int = 0) -> dict:
 
     """
     return item(res, idx).as_dict()
+
+
+def as_none(res: noderpc.ExecutionResult, idx: int = 0) -> None:
+    """
+    Convert the stack item at `idx` to None
+
+    Args:
+        res:
+        idx: the index in the result stack to fetch the stack item from.
+
+    Raises:
+        ValueError: if the index is out of range, or the value is not None
+    """
+    return item(res, idx).as_none()
 
 
 def item(res: noderpc.ExecutionResult, idx: int = 0) -> noderpc.StackItem:

--- a/neo3/api/noderpc.py
+++ b/neo3/api/noderpc.py
@@ -297,7 +297,7 @@ class StackItem:
             data = bytes.fromhex(data.decode())
         return cryptography.ECPoint.deserialize_from_bytes(data, validate=True)
 
-    def as_list(self) -> list:
+    def as_list(self) -> list[StackItem]:
         if self.type != StackItemType.ARRAY:
             raise ValueError(
                 f"item is not of type '{StackItemType.ARRAY}' but of type '{self.type}'"
@@ -311,6 +311,15 @@ class StackItem:
             )
         m = cast(MapStackItem, self)
         return dict(m.items())
+
+    def as_none(self) -> None:
+        if self.type != StackItemType.ANY:
+            raise ValueError(
+                f"item is not of type '{StackItemType.ANY}' but of type '{self.type}'"
+            )
+        if self.value is not None:
+            raise ValueError(f"value is not None but of type '{type(self.value)}")
+        return self.value
 
 
 class MapStackItem(StackItem):


### PR DESCRIPTION
Instead of wrapping the `ManagementContract` native contract we take a different approach that's more usage friendly
* a static `deploy()` on the base class `GenericContract`
* instance `update` and `destroy` on `GenericContract`

The benefit over wrapping `ManagementContract` is that this approach takes less arguments for the functions. The `ManagementContract` also has only 1 additional useful function we could wrap being `getMinimumDeploymentFee`.