### PR TITLE
api: drop Config class

### DIFF
--- a/docs/source/smart-contracts.md
+++ b/docs/source/smart-contracts.md
@@ -135,7 +135,7 @@ async def main():
     account = wallet.account_default
     
     facade = ChainFacade.node_provider_mainnet()
-    facade.config.add_signer(
+    facade.add_signer(
         sign_insecure_with_account(account, pw="123"),
         Signer(account.script_hash)
     )
@@ -164,7 +164,7 @@ wallet that we'll load from disk.
 Next up is setting up and configuring the facade to automatically sign our transaction(s).
 ```py3 linenums="14"
 facade = ChainFacade.node_provider_mainnet()
-facade.config.add_signer(
+facade.add_signer(
     sign_insecure_with_account(account, pw="123"),
     Signer(account.script_hash)
 )

--- a/examples/contract-deploy-update-destroy.py
+++ b/examples/contract-deploy-update-destroy.py
@@ -5,7 +5,7 @@ Finally, the contract is destroyed.
 """
 
 import asyncio
-from neo3.api.wrappers import GenericContract, Config, ChainFacade
+from neo3.api.wrappers import GenericContract, ChainFacade
 from neo3.api.helpers.signing import sign_insecure_with_account
 from neo3.api.helpers import unwrap
 from neo3.contracts import nef, manifest
@@ -17,13 +17,12 @@ async def main(neoxp: shared.NeoExpress):
     wallet = shared.user_wallet
     account = wallet.account_default
 
-    config = Config(rpc_host=neoxp.rpc_host)
-    config.add_signer(
+    # This is your interface for talking to the blockchain
+    facade = ChainFacade(rpc_host=neoxp.rpc_host)
+    facade.add_signer(
         sign_insecure_with_account(account, pw="123"),
         Signer(account.script_hash),  # default scope is CALLED_BY_ENTRY
     )
-    # This is your interface for talking to the blockchain
-    facade = ChainFacade(config)
 
     files_path = f"{shared.shared_dir}/deploy-update-destroy/"
 

--- a/examples/nep-11-airdrop.py
+++ b/examples/nep-11-airdrop.py
@@ -2,7 +2,7 @@
 This example shows how to send NFTs to multiple accounts in one go (airdrop).
 """
 import asyncio
-from neo3.api.wrappers import Config, ChainFacade, GasToken, NEP11NonDivisibleContract
+from neo3.api.wrappers import ChainFacade, GasToken, NEP11NonDivisibleContract
 from neo3.api.helpers.signing import sign_insecure_with_account
 from neo3.network.payloads.verification import Signer
 from examples import shared
@@ -12,12 +12,12 @@ async def example_airdrop(neoxp: shared.NeoExpress):
     wallet = shared.user_wallet
     account = wallet.account_default
 
-    config = Config(rpc_host=neoxp.rpc_host)
-    config.add_signer(
+    # This is your interface for talking to the blockchain
+    facade = ChainFacade(rpc_host=neoxp.rpc_host)
+    facade.add_signer(
         sign_insecure_with_account(account, pw="123"),
         Signer(account.script_hash),  # default scope is CALLED_BY_ENTRY
     )
-    facade = ChainFacade(config)
 
     # Wrap the NFT contract
     ntf = NEP11NonDivisibleContract(shared.nep11_token_hash)
@@ -58,7 +58,6 @@ async def example_airdrop(neoxp: shared.NeoExpress):
     print("Airdropping 1 NFT to each address and waiting for receipt...", end="")
     receipt = await facade.invoke(
         ntf.transfer_multi(destination_addresses, token_ids),
-        receipt_retry_delay=1,
     )
     print(receipt.result)
 

--- a/examples/nep17-airdrop.py
+++ b/examples/nep17-airdrop.py
@@ -3,7 +3,7 @@ This example shows how to send tokens to multiple accounts in one go.
 It will mint the "COZ Token"
 """
 import asyncio
-from neo3.api.wrappers import Config, ChainFacade, NeoToken, NEP17Contract
+from neo3.api.wrappers import ChainFacade, NeoToken, NEP17Contract
 from neo3.api.helpers.signing import sign_insecure_with_account
 from neo3.network.payloads.verification import Signer
 from examples import shared
@@ -14,12 +14,12 @@ async def example_airdrop(neoxp: shared.NeoExpress):
     wallet = shared.user_wallet
     account = wallet.account_default
 
-    config = Config(rpc_host=neoxp.rpc_host)
-    config.add_signer(
+    # This is your interface for talking to the blockchain
+    facade = ChainFacade(rpc_host=neoxp.rpc_host)
+    facade.add_signer(
         sign_insecure_with_account(account, pw="123"),
         Signer(account.script_hash),  # default scope is CALLED_BY_ENTRY
     )
-    facade = ChainFacade(config)
 
     # Use the generic NEP17 class to wrap the token
     token = NEP17Contract(shared.coz_token_hash)

--- a/examples/nep17-transfer.py
+++ b/examples/nep17-transfer.py
@@ -4,7 +4,7 @@ has an existing wrapper (like NEO) and how to transfer for any arbitrary contrac
 implements the NEP-17 standard
 """
 import asyncio
-from neo3.api.wrappers import Config, ChainFacade, NeoToken, NEP17Contract
+from neo3.api.wrappers import ChainFacade, NeoToken, NEP17Contract
 from neo3.api.helpers.signing import sign_insecure_with_account
 from neo3.network.payloads.verification import Signer
 from neo3.core import types
@@ -16,12 +16,12 @@ async def example_transfer_neo(neoxp: shared.NeoExpress):
     wallet = shared.user_wallet
     account = wallet.account_default
 
-    config = Config(rpc_host=neoxp.rpc_host)
-    config.add_signer(
+    # This is your interface for talking to the blockchain
+    facade = ChainFacade(rpc_host=neoxp.rpc_host)
+    facade.add_signer(
         sign_insecure_with_account(account, pw="123"),
         Signer(account.script_hash),  # default scope is CALLED_BY_ENTRY
     )
-    facade = ChainFacade(config)
 
     source = account.address
     destination = "NUVaphUShQPD82yoXcbvFkedjHX6rUF7QQ"
@@ -38,12 +38,12 @@ async def example_transfer_other(neoxp: shared.NeoExpress):
     wallet = shared.user_wallet
     account = wallet.account_default
 
-    config = Config(rpc_host=neoxp.rpc_host)
-    config.add_signer(
+    # This is your interface for talking to the blockchain
+    facade = ChainFacade(rpc_host=neoxp.rpc_host)
+    facade.add_signer(
         sign_insecure_with_account(account, pw="123"),
         Signer(account.script_hash),  # default scope is CALLED_BY_ENTRY
     )
-    facade = ChainFacade(config)
 
     source = account.address
     destination = "NUVaphUShQPD82yoXcbvFkedjHX6rUF7QQ"

--- a/examples/vote.py
+++ b/examples/vote.py
@@ -2,7 +2,7 @@
 This example shows how to vote for your favourite consensus node
 """
 import asyncio
-from neo3.api.wrappers import Config, ChainFacade, NeoToken
+from neo3.api.wrappers import ChainFacade, NeoToken
 from neo3.api.helpers.signing import sign_insecure_with_account
 from neo3.network.payloads.verification import Signer
 from examples import shared
@@ -12,13 +12,12 @@ async def example_vote(neoxp: shared.NeoExpress):
     wallet = shared.user_wallet
     account = wallet.account_default
 
-    config = Config(rpc_host=neoxp.rpc_host)
-    config.add_signer(
-        sign_insecure_with_account(account, pw="123"),
-        Signer(account.script_hash),  # default scope is CALLED_BY_ENTRY
-    )
     # This is your interface for talking to the blockchain
-    facade = ChainFacade(config)
+    facade = ChainFacade(rpc_host=neoxp.rpc_host)
+    facade.add_signer(
+        sign_insecure_with_account(account, pw="123"),
+        Signer(account.script_hash),
+    )
 
     # Dedicated Neo native contract wrapper
     neo = NeoToken()

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -5,6 +5,10 @@ from neo3.contracts import callflags
 
 
 class ScriptBuilderTestCase(unittest.TestCase):
+    def shortDescription(self):
+        # disable docstring printing in test runner
+        return None
+
     def test_emit(self):
         # test emit opcode without operand
         sb = vm.ScriptBuilder()


### PR DESCRIPTION
The `Config` class (as input to `ChainFacade`) ended up not really having a good purpose anymore in the final design. 