### PR TITLE
api, docs, examples: align naming convention of password

### DIFF
--- a/docs/source/smart-contracts.md
+++ b/docs/source/smart-contracts.md
@@ -136,7 +136,7 @@ async def main():
     
     facade = ChainFacade.node_provider_mainnet()
     facade.add_signer(
-        sign_insecure_with_account(account, pw="123"),
+        sign_insecure_with_account(account, password="123"),
         Signer(account.script_hash)
     )
     
@@ -165,7 +165,7 @@ Next up is setting up and configuring the facade to automatically sign our trans
 ```py3 linenums="14"
 facade = ChainFacade.node_provider_mainnet()
 facade.add_signer(
-    sign_insecure_with_account(account, pw="123"),
+    sign_insecure_with_account(account, password="123"),
     Signer(account.script_hash)
 )
 ```

--- a/examples/contract-deploy-update-destroy.py
+++ b/examples/contract-deploy-update-destroy.py
@@ -20,7 +20,7 @@ async def main(neoxp: shared.NeoExpress):
     # This is your interface for talking to the blockchain
     facade = ChainFacade(rpc_host=neoxp.rpc_host)
     facade.add_signer(
-        sign_insecure_with_account(account, pw="123"),
+        sign_insecure_with_account(account, password="123"),
         Signer(account.script_hash),  # default scope is CALLED_BY_ENTRY
     )
 

--- a/examples/nep-11-airdrop.py
+++ b/examples/nep-11-airdrop.py
@@ -15,7 +15,7 @@ async def example_airdrop(neoxp: shared.NeoExpress):
     # This is your interface for talking to the blockchain
     facade = ChainFacade(rpc_host=neoxp.rpc_host)
     facade.add_signer(
-        sign_insecure_with_account(account, pw="123"),
+        sign_insecure_with_account(account, password="123"),
         Signer(account.script_hash),  # default scope is CALLED_BY_ENTRY
     )
 

--- a/examples/nep17-airdrop.py
+++ b/examples/nep17-airdrop.py
@@ -17,7 +17,7 @@ async def example_airdrop(neoxp: shared.NeoExpress):
     # This is your interface for talking to the blockchain
     facade = ChainFacade(rpc_host=neoxp.rpc_host)
     facade.add_signer(
-        sign_insecure_with_account(account, pw="123"),
+        sign_insecure_with_account(account, password="123"),
         Signer(account.script_hash),  # default scope is CALLED_BY_ENTRY
     )
 

--- a/examples/nep17-transfer.py
+++ b/examples/nep17-transfer.py
@@ -19,7 +19,7 @@ async def example_transfer_neo(neoxp: shared.NeoExpress):
     # This is your interface for talking to the blockchain
     facade = ChainFacade(rpc_host=neoxp.rpc_host)
     facade.add_signer(
-        sign_insecure_with_account(account, pw="123"),
+        sign_insecure_with_account(account, password="123"),
         Signer(account.script_hash),  # default scope is CALLED_BY_ENTRY
     )
 
@@ -41,7 +41,7 @@ async def example_transfer_other(neoxp: shared.NeoExpress):
     # This is your interface for talking to the blockchain
     facade = ChainFacade(rpc_host=neoxp.rpc_host)
     facade.add_signer(
-        sign_insecure_with_account(account, pw="123"),
+        sign_insecure_with_account(account, password="123"),
         Signer(account.script_hash),  # default scope is CALLED_BY_ENTRY
     )
 

--- a/examples/vote.py
+++ b/examples/vote.py
@@ -15,7 +15,7 @@ async def example_vote(neoxp: shared.NeoExpress):
     # This is your interface for talking to the blockchain
     facade = ChainFacade(rpc_host=neoxp.rpc_host)
     facade.add_signer(
-        sign_insecure_with_account(account, pw="123"),
+        sign_insecure_with_account(account, password="123"),
         Signer(account.script_hash),
     )
 

--- a/neo3/api/helpers/signing.py
+++ b/neo3/api/helpers/signing.py
@@ -17,7 +17,7 @@ class SigningDetails:
 SigningFunction = Callable[[transaction.Transaction, SigningDetails], Awaitable]
 
 
-def sign_insecure_with_account(acc: account.Account, pw: str) -> SigningFunction:
+def sign_insecure_with_account(acc: account.Account, password: str) -> SigningFunction:
     """
     Sign and add a witness using the account and the provided account password
     """
@@ -26,12 +26,14 @@ def sign_insecure_with_account(acc: account.Account, pw: str) -> SigningFunction
         tx: transaction.Transaction, details: SigningDetails
     ):
         # this will automatically add a witness
-        acc.sign_tx(tx, pw, details.network)
+        acc.sign_tx(tx, password, details.network)
 
     return insecure_account_signer
 
 
-def sign_secure_with_account(acc: account.Account, env_pw_name: str) -> SigningFunction:
+def sign_secure_with_account(
+    acc: account.Account, env_password_name: str
+) -> SigningFunction:
     """
     Sign and add a witness using the account. The account password is read from the environment variables.
     """
@@ -40,7 +42,7 @@ def sign_secure_with_account(acc: account.Account, env_pw_name: str) -> SigningF
         tx: transaction.Transaction, details: SigningDetails
     ):
         # this will automatically add a witness
-        acc.sign_tx(tx, os.environ[env_pw_name], details.network)
+        acc.sign_tx(tx, os.environ[env_password_name], details.network)
 
     return insecure_account_signer
 


### PR DESCRIPTION
most parameters used `password` (e.g. everything in `Account` and `Wallet`). This streamlines it across the code base