### PR TITLE
setup: OSX M1 support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,8 +39,8 @@ install_requires =
 	lz4==4.0.2
 	neo3crypto==0.3
 	netaddr>=0.8.0
-	orjson>=3.4.6
-	pycryptodome==3.11.0
+	orjson>=3.8.2
+	pycryptodome==3.15.0
 	pybiginteger==1.2.7
 	pybiginteger-stubs==1.2.7
 


### PR DESCRIPTION
NSPCC tested the 3rd party native extensions to work correctly with M1 Mac on Python 3.10. This bumps the versions of those packages. `neo3crypto` and `pybiginteger` versions did not change and just got an M1 wheel added and pushed to pypi. They did test `pybiginteger` just to make sure the build changes produce something valid.