### PR TITLE
docs: include network payloads in API reference, restructure ipfilter docs

### DIFF
--- a/neo3/network/ipfilter.py
+++ b/neo3/network/ipfilter.py
@@ -2,53 +2,6 @@
 
 A global instance ``ipfilter`` can be imported directly from the module and is taken into account by default in the
 `NeoNode` class when connections are established.
-
-Filtering rules
-
-* The whitelist has precedence over the blacklist settings.
-* Host masks can be applied.
-* When using host masks do not set host bits (leave them to 0) or an exception will occur.
-
-The following are `configuration` examples for common scenario's.
-
-1. Accept only specific trusted IPs.
-
-        {
-            'blacklist': [
-                '0.0.0.0/0'
-            ],
-            'whitelist': [
-                '10.10.10.10',
-                '15.15.15.15'
-            ]
-        }
-
-2. Accept only a range of trusted IPs.
-
-        # Accepts any IP in the range of 10.10.10.0 - 10.10.10.255
-
-        {
-            'blacklist': [
-                '0.0.0.0/0'
-            ],
-            'whitelist': [
-                '10.10.10.0/24',
-            ]
-        }
-
-3. Accept all except specific IPs.
-
-        # Can be used for banning bad actors
-
-        {
-            'blacklist': [
-                '12.12.12.12',
-                '13.13.13.13'
-            ],
-            'whitelist': [
-            ]
-        }
-
 """
 from ipaddress import IPv4Network
 from contextlib import suppress
@@ -56,6 +9,53 @@ from copy import deepcopy
 
 
 class IPFilter:
+    """
+    Filtering rules.
+
+    * The whitelist has precedence over the blacklist settings.
+    * Host masks can be applied.
+    * When using host masks do not set host bits (leave them to 0) or an exception will occur.
+
+    The following are `configuration` examples for common scenario's.
+
+    1. Accept only specific trusted IPs.
+
+            {
+                'blacklist': [
+                    '0.0.0.0/0'
+                ],
+                'whitelist': [
+                    '10.10.10.10',
+                    '15.15.15.15'
+                ]
+            }
+
+    2. Accept only a range of trusted IPs.
+
+            # Accepts any IP in the range of 10.10.10.0 - 10.10.10.255
+
+            {
+                'blacklist': [
+                    '0.0.0.0/0'
+                ],
+                'whitelist': [
+                    '10.10.10.0/24',
+                ]
+            }
+
+    3. Accept all except specific IPs.
+
+            # Can be used for banning bad actors
+
+            {
+                'blacklist': [
+                    '12.12.12.12',
+                    '13.13.13.13'
+                ],
+                'whitelist': [
+                ]
+            }
+    """
 
     default_config: dict = {"blacklist": [], "whitelist": []}
 

--- a/neo3/network/payloads/__init__.py
+++ b/neo3/network/payloads/__init__.py
@@ -1,0 +1,3 @@
+"""
+P2P network payloads and related classes.
+"""

--- a/neo3/network/payloads/address.py
+++ b/neo3/network/payloads/address.py
@@ -1,3 +1,6 @@
+"""
+Node address information.
+"""
 from __future__ import annotations
 from typing import Optional
 from datetime import datetime
@@ -37,7 +40,7 @@ class DisconnectReason(IntEnum):
     """
     Reason for disconnecting a node.
 
-    Will also be broadcast back to the node when `this PR <https://github.com/neo-project/neo/pull/1154>`__ is merged.
+    Will also be broadcast back to the node when [this PR](https://github.com/neo-project/neo/pull/1154>) is merged.
     For now only used internally with logging.
     """
 
@@ -51,6 +54,10 @@ class DisconnectReason(IntEnum):
 
 
 class NetworkAddress(serialization.ISerializable):
+    """
+    Address properties.
+    """
+
     def __init__(
         self,
         address: str,
@@ -102,40 +109,70 @@ class NetworkAddress(serialization.ISerializable):
 
     @property
     def ip(self) -> str:
+        """
+        Get ip.
+        """
         host, port = self.address.split(":")
         return host
 
     @property
     def port(self) -> int:
+        """
+        Get port.
+        """
         host, port = self.address.split(":")
         return int(port)
 
     @property
     def is_state_new(self) -> bool:
+        """
+        Test if state is `new`.
+        """
         return self.state == AddressState.NEW
 
     def set_state_new(self) -> None:
+        """
+        Set state attribute to `new`.
+        """
         self.state = AddressState.NEW
 
     @property
     def is_state_connected(self) -> bool:
+        """
+        Test if state is `connected`.
+        """
         return self.state == AddressState.CONNECTED
 
     def set_state_connected(self) -> None:
+        """
+        Set state attribute to `connected`.
+        """
         self.state = AddressState.CONNECTED
 
     @property
     def is_state_poor(self) -> bool:
+        """
+        Test if state is `poor`.
+        """
         return self.state == AddressState.POOR
 
     def set_state_poor(self) -> None:
+        """
+        Set state attribute to `poor`.
+        """
         self.state = AddressState.POOR
 
     @property
     def is_state_dead(self) -> bool:
+        """
+        Test if state is `dead`.
+        """
         return self.state == AddressState.DEAD
 
     def set_state_dead(self) -> None:
+        """
+        Set state attribute to `dead`.
+        """
         self.state = AddressState.DEAD
 
     def serialize(self, writer: serialization.BinaryWriter) -> None:
@@ -180,6 +217,10 @@ class NetworkAddress(serialization.ISerializable):
 
 
 class AddrPayload(serialization.ISerializable):
+    """
+    Address payload with list of address information entries.
+    """
+
     def __init__(self, addresses: Sequence[NetworkAddress]):
         self.addresses = list(addresses)
 

--- a/neo3/network/payloads/extensible.py
+++ b/neo3/network/payloads/extensible.py
@@ -1,3 +1,6 @@
+"""
+Customizable payload.
+"""
 from __future__ import annotations
 import hashlib
 from neo3.core import types, serialization, Size as s, utils
@@ -5,6 +8,10 @@ from neo3.network.payloads import inventory, verification
 
 
 class ExtensiblePayload(inventory.IInventory):
+    """
+    A payload that supports arbitrary `data`.
+    """
+
     # Comes from neo3.network.message.Message.PAYLOAD_MAX_SIZE but wanted to break the import cycle
     # despite not causing any circular imported errors yet
     PAYLOAD_MAX_SIZE = 0x2000000

--- a/neo3/network/payloads/filter.py
+++ b/neo3/network/payloads/filter.py
@@ -1,3 +1,6 @@
+"""
+Bloomfilter payloads.
+"""
 from __future__ import annotations
 from neo3.core import serialization, utils, Size as s, cryptography as crypto
 

--- a/neo3/network/payloads/inventory.py
+++ b/neo3/network/payloads/inventory.py
@@ -17,10 +17,7 @@ class InventoryPayload(serialization.ISerializable):
     """
     A payload used to share inventory hashes.
 
-    See also:
-        - :ref:`getblocks <message-usage-getblocks>`
-        - :ref:`getdata <message-usage-getdata>`
-        - :ref:`mempool <message-usage-mempool>`
+    Use by `getdata`, `getblocks` and `mempool` message types.
     """
 
     def __init__(self, type: InventoryType, hashes: Sequence[types.UInt256]):
@@ -66,6 +63,10 @@ class InventoryPayload(serialization.ISerializable):
 
 
 class IInventory(verification.IVerifiable):
+    """
+    Inventory interface.
+    """
+
     @abc.abstractmethod
     def hash(self) -> types.UInt256:
         """"""

--- a/neo3/network/payloads/ping.py
+++ b/neo3/network/payloads/ping.py
@@ -1,3 +1,6 @@
+"""
+Heartbeat payload with chain height information.
+"""
 from __future__ import annotations
 from datetime import datetime
 from random import randint

--- a/neo3/network/payloads/version.py
+++ b/neo3/network/payloads/version.py
@@ -1,3 +1,6 @@
+"""
+Payload containing node information.
+"""
 from __future__ import annotations
 import datetime
 from neo3.core import Size as s, serialization, utils


### PR DESCRIPTION
* enabled `network.payloads` inclusion in the API generator and cleaned up/added doc strings to the classes
* ipfilter docs were taking up too much space in the `neo3.network` overview page due to the included examples. Moved those to inside the `IPFilter` class docstrings to cut down on the overview clutter