### PR TITLE
docs: disable dark theme

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -26,17 +26,17 @@ theme:
   palette:
     # Palette toggle for light mode
     - scheme: default
-      toggle:
-        icon: material/toggle-switch
-        name: Switch to dark mode
+#      toggle:
+#        icon: material/toggle-switch
+#        name: Switch to dark mode
       primary: yellow
 
-    # Palette toggle for dark mode
-    - scheme: slate
-      toggle:
-        icon: material/toggle-switch-off-outline
-        name: Switch to light mode
-      primary: yellow
+#    # Palette toggle for dark mode
+#    - scheme: slate
+#      toggle:
+#        icon: material/toggle-switch-off-outline
+#        name: Switch to light mode
+#      primary: yellow
 nav:
   - Home: 'index.md'
   - Getting started: 'getting-started.md'


### PR DESCRIPTION
it needs to be fixed for the API doc reference

example issues
<img width="1087" alt="Screenshot 2022-12-02 at 11 43 20" src="https://user-images.githubusercontent.com/6625537/205275224-3e6c2ba4-5d19-47c2-99ae-ce8a54825d75.png">
