### PR TITLE
ci: fix pypi publishing

### DIFF
--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -28,14 +28,14 @@ jobs:
       - if: github.event.inputs.pypi-target == 'Main'
         name: Publish to PyPi
         env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
           twine upload dist/*
       - if: github.event.inputs.pypi-target == 'Test'
         name: Publish to Test-PyPi
         env:
-          TWINE_USERNAME: ${{ secrets.PYPI_TEST_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_TEST_PASSWORD }}
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TEST_API_TOKEN }}
         run: |
           twine upload --repository testpypi dist/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ docs =
 	mkdocs==1.4.1
 	mkdocs-material==8.5.7
 	mkdocs-material-extensions==1.1
-	mkapi-fix @ git+https://github.com/CityOfZion/mkapi.git@757fe183fab43998031bcf5c21487f61dcee575e
+	mkapi-fix-coz==0.1.0
 
 [coverage:run]
 source = neo3


### PR DESCRIPTION
This fixes 2 issues
1. warnings by PyPi regarding the need to use API token when publishing
2. errors when uploading to PyPi because we had a dependency that used a git commit. Which apparently is not allowed according to https://peps.python.org/pep-0440/#direct-references
    > Public index servers SHOULD NOT allow the use of direct references in uploaded distributions. Direct references are intended as a tool for software integrators rather than publishers.