### PR TITLE
ci: update CI shield badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
 neo-mamba
 -----------
 
-.. image:: https://img.shields.io/github/workflow/status/CityOfZion/neo-mamba/CI
+.. image:: https://img.shields.io/github/actions/workflow/status/CityOfZion/neo-mamba/validate-pr-commit.yml?branch=master
   :target: https://shields.io/
 
 .. image:: https://coveralls.io/repos/github/CityOfZion/neo-mamba/badge.svg?branch=master


### PR DESCRIPTION
shields.io made a [breaking change](https://github.com/badges/shields/issues/8671) that results in the CI status badge being shown as
<img width="326" alt="image" src="https://user-images.githubusercontent.com/6625537/208048191-9545045f-3e9d-4b5d-af46-6050a4e89357.png">
this fixes that to 
<img width="104" alt="image" src="https://user-images.githubusercontent.com/6625537/208048355-1e147d58-19f1-4d3d-80e3-f8d7222d082b.png">

