### PR TITLE
Maybe we need to specify the supported Python versions in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ classifiers =
 	Programming Language :: Python :: 3.10
 
 [options]
-python_requires = >= 3.9
+python_requires = == 3.10
 zip_safe = False
 include_package_data = True
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifiers =
 	Programming Language :: Python :: 3.10
 
 [options]
+python_requires = >= 3.9
 zip_safe = False
 include_package_data = True
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ classifiers =
 	Programming Language :: Python :: 3.10
 
 [options]
-python_requires = == 3.10
+python_requires = == 3.10.*
 zip_safe = False
 include_package_data = True
 packages = find:


### PR DESCRIPTION
For example, we are using such typing annotations everywhere:
https://github.com/CityOfZion/neo-mamba/blob/c3eefed337ea3d6443be981b40b43ab7e9280c0b/neo3/core/cryptography/merkletree.py#L28
where UInt256 is, after all, inherited from an ABCMeta class. 
```python
class UInt256(_UIntBase):
class _UIntBase(serialization.ISerializable):
class ISerializable(abc.ABC):
```
In Python 3.8 and 3.7, typing annotation using an ABCMeta class is not supported. An exception can be raised as:
```
TypeError: 'ABCMeta' object is not subscriptable
```
And Python <= 3.6 does not support such typing annotations from the syntax level.