### PR TITLE
vm: support dict in script builder

### DIFF
--- a/neo3/vm.py
+++ b/neo3/vm.py
@@ -337,6 +337,17 @@ class ScriptBuilder:
                 self.emit_push(v)
                 self.emit(OpCode.APPEND)
             return self
+        elif isinstance(value, dict):
+            for k, v in value.items():
+                # This restriction exists on the VM side where keys to a 'Map' may only be of 'PrimitiveType'
+                if not isinstance(k, (int, str, bool)):
+                    raise ValueError(
+                        f"Unsupported key type {type(k)}. Supported types by the VM are bool, int and str"
+                    )
+                self.emit_push(v)
+                self.emit_push(k)
+            self.emit_push(len(value))
+            self.emit(OpCode.PACKMAP)
         else:
             raise ValueError(f"Unsupported value type {type(value)}")
 

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -138,6 +138,23 @@ class ScriptBuilderTestCase(unittest.TestCase):
         #     sb.emit_push(data)
         # self.assertIn("Value is too long", str(context.exception))
 
+    def test_emit_push_dict(self):
+        data = {"a": 123, "b": 456}
+
+        sb = vm.ScriptBuilder()
+        sb.emit_push(data)
+        expected = "007b0c016101c8010c016212be"
+        self.assertEqual(expected, sb.to_array().hex())
+
+        # test invalid key type
+        sb = vm.ScriptBuilder()
+        with self.assertRaises(ValueError) as context:
+            sb.emit_push({1.0: "abc"})
+        self.assertEqual(
+            "Unsupported key type <class 'float'>. Supported types by the VM are bool, int and str",
+            str(context.exception),
+        )
+
     def test_emit_push_unsupported(self):
         class Unsupported:
             pass


### PR DESCRIPTION
The NEO ABI supports a `Map` type ([ref](https://github.com/neo-project/proposals/blob/master/nep-14.mediawiki#user-content-ParameterType)) as input parameter and return type. A `Map` is pretty similar to Pythons `dict` with the exception that the keys are limited to `bool`,`str` and `int`. While it is not used much, it is good to have convenient support for it in the ScriptBuilder class.