### PR TITLE
api: fix type of data argument

### DIFF
--- a/neo3/api/wrappers.py
+++ b/neo3/api/wrappers.py
@@ -660,7 +660,7 @@ class GenericContract:
         update_method: str = "update",
         nef: Optional[nef.NEF] = None,
         manifest: Optional[manifest.ContractManifest] = None,
-        data: Optional[list] = None,
+        data: Optional[noderpc.ContractParameter] = None,
     ) -> ContractMethodResult[None]:
         """
         Update this contract on chain with a new manifest and/or contract (NEF).
@@ -703,7 +703,7 @@ class GenericContract:
     def deploy(
         nef: nef.NEF,
         manifest: manifest.ContractManifest,
-        data: Optional[list] = None,
+        data: Optional[noderpc.ContractParameter] = None,
     ) -> ContractMethodResult[types.UInt160]:
         """
         Deploy a smart contract to the chain.
@@ -881,7 +881,7 @@ class NEP17Contract(_TokenContract):
         source: types.UInt160 | NeoAddress,
         destinations: Sequence[types.UInt160 | NeoAddress],
         amount: int,
-        data: Optional[list] = None,
+        data: Optional[noderpc.ContractParameter] = None,
         abort_on_failure: bool = False,
     ) -> ContractMethodResult[bool]:
         """
@@ -1222,7 +1222,7 @@ class NEP11DivisibleContract(_NEP11Contract):
         destination: types.UInt160 | NeoAddress,
         amount: int,
         token_id: bytes,
-        data: Optional[list] = None,
+        data: Optional[noderpc.ContractParameter] = None,
     ) -> ContractMethodResult[bool]:
         """
         Transfer `amount` of `token_id` from `source` account to `destination` account.
@@ -1313,7 +1313,7 @@ class NEP11NonDivisibleContract(_NEP11Contract):
         self,
         destination: types.UInt160 | NeoAddress,
         token_id: bytes,
-        data: Optional[list] = None,
+        data: Optional[noderpc.ContractParameter] = None,
     ) -> ContractMethodResult[bool]:
         """
         Transfer `token_id` to `destination` account.
@@ -1343,7 +1343,7 @@ class NEP11NonDivisibleContract(_NEP11Contract):
         self,
         destinations: Sequence[types.UInt160 | NeoAddress],
         token_ids: list[bytes],
-        data: Optional[list] = None,
+        data: Optional[noderpc.ContractParameter] = None,
         abort_on_failure: bool = False,
     ) -> ContractMethodResult[bool]:
         """

--- a/neo3/api/wrappers.py
+++ b/neo3/api/wrappers.py
@@ -818,7 +818,7 @@ class NEP17Contract(_TokenContract):
         source: types.UInt160 | NeoAddress,
         destination: types.UInt160 | NeoAddress,
         amount: int,
-        data: Optional[noderpc.ContractParameter | list[noderpc.ContractParameter]] = None,
+        data: Optional[noderpc.ContractParameter] = None,
     ) -> ContractMethodResult[bool]:
         """
         Transfer `amount` of tokens from `source` account to `destination` account.

--- a/neo3/api/wrappers.py
+++ b/neo3/api/wrappers.py
@@ -638,7 +638,7 @@ class GenericContract:
     def call_function(
         self,
         name,
-        args: Optional[Sequence] = None,
+        args: Optional[noderpc.ContractParameter] = None,
     ) -> ContractMethodResult[noderpc.ExecutionResult]:
         """
         Call a method on the contract.

--- a/neo3/api/wrappers.py
+++ b/neo3/api/wrappers.py
@@ -818,7 +818,7 @@ class NEP17Contract(_TokenContract):
         source: types.UInt160 | NeoAddress,
         destination: types.UInt160 | NeoAddress,
         amount: int,
-        data: Optional[list] = None,
+        data: Optional[noderpc.ContractParameter | list[noderpc.ContractParameter]] = None,
     ) -> ContractMethodResult[bool]:
         """
         Transfer `amount` of tokens from `source` account to `destination` account.


### PR DESCRIPTION
The type of the `data` argument is incorrectly set to assume a list. It can actually be any accepted contract parameter type, whether in a list or not.