### PR TITLE
ci: resolve setup-python deprecation warning

### DIFF
--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4.6.1
         with:
           python-version: '3.10'
       - name: Create dist

--- a/.github/workflows/validate-pr-commit.yml
+++ b/.github/workflows/validate-pr-commit.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           path: 'mamba'
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4.2.0
+        uses: actions/setup-python@v4.6.1
         with:
           python-version: ${{ matrix.python-version }}
           check-latest: true
@@ -66,7 +66,7 @@ jobs:
         with:
           name: setup-artifact-ubuntu-20.04-py3.10
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4.2.0
+        uses: actions/setup-python@v4.6.1
         with:
           python-version: "3.10"
           check-latest: true
@@ -90,7 +90,7 @@ jobs:
         with:
           name: setup-artifact-${{ matrix.os }}-py${{ matrix.python-version }}
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4.2.0
+        uses: actions/setup-python@v4.6.1
         with:
           python-version: '${{ matrix.python-version }}'
           check-latest: true
@@ -119,7 +119,7 @@ jobs:
         with:
           name: setup-artifact-ubuntu-20.04-py3.10
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4.2.0
+        uses: actions/setup-python@v4.6.1
         with:
           python-version: "3.10"
           check-latest: true


### PR DESCRIPTION
Resolve this
```
Run actions/setup-python@v4.2.0
Resolved as '3.10.11'

Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-[10](https://github.com/CityOfZion/neo-mamba/actions/runs/5376319722/jobs/9753387841#step:3:11)-[11](https://github.com/CityOfZion/neo-mamba/actions/runs/5376319722/jobs/9753387841#step:3:12)-github-actions-deprecating-save-state-and-set-output-commands/
Successfully set up CPython (3.[1](https://github.com/CityOfZion/neo-mamba/actions/runs/5376319722/jobs/9753387841#step:5:1)0.11)
```