### PR TITLE
wallet: fix Wallet.from_json/from_file for multiple accounts with passwords

### DIFF
--- a/tests/wallet/test_account.py
+++ b/tests/wallet/test_account.py
@@ -121,3 +121,11 @@ class AccountCreationTestCase(unittest.TestCase):
                     testcase["encrypted_key"], "wrong password"
                 )
             self.assertIn("Wrong passphrase", str(context.exception))
+
+    def test_new_account_no_password(self):
+        with self.assertRaises(ValueError) as context:
+            account.Account()
+        self.assertIn(
+            "Can't create an account without a password unless it is a watch only account",
+            str(context.exception),
+        )


### PR DESCRIPTION
A wallet can have multiple accounts that are all encrypted with different passwords. It appears that we only tested loading a wallet from a file where the accounts coincidentally had the same password for all accounts.

This PR changes the signature of `from_file()` and from_json()` to have a list of passwords instead of a single password. 

### This is a backwards incompatible change