### PR TITLE
api: add 1 out n multi-sig signing support for use with ChainFacade

### DIFF
--- a/neo3/api/helpers/signing.py
+++ b/neo3/api/helpers/signing.py
@@ -63,3 +63,20 @@ def sign_on_remote_server() -> SigningFunction:
         raise NotImplementedError
 
     return remote_server_signer
+
+# TODO: should probably take a list of accounts and a list of passwords
+# create a test scenario with a 2 out of 3 account
+def sign_insecure_with_multisig_account(acc: account.Account, password: str) -> SigningFunction:
+    """
+    Sign and add a witness using the account and the provided account password.
+    """
+
+    async def insecure_account_signer(
+        tx: transaction.Transaction, details: SigningDetails
+    ):
+        # TODO: set the expected public keys
+        ctx = account.MultiSigContext()
+        # this will automatically add a witness
+        acc.sign_multisig_tx(tx, password, ctx, details.network)
+
+    return insecure_account_signer

--- a/neo3/api/helpers/signing.py
+++ b/neo3/api/helpers/signing.py
@@ -64,17 +64,23 @@ def sign_on_remote_server() -> SigningFunction:
 
     return remote_server_signer
 
-# TODO: should probably take a list of accounts and a list of passwords
-# create a test scenario with a 2 out of 3 account
-def sign_insecure_with_multisig_account(acc: account.Account, password: str) -> SigningFunction:
+
+def sign_insecure_with_multisig_account(
+    acc: account.Account, password: str
+) -> SigningFunction:
     """
-    Sign and add a witness using the account and the provided account password.
+    Sign and add a multi-signature witness.
+
+    This only works for a 1 out of n multi-signature account.
+
+    Args:
+        acc: a multi-signature account
+        password: the password of the account to sign with
     """
 
     async def insecure_account_signer(
         tx: transaction.Transaction, details: SigningDetails
     ):
-        # TODO: set the expected public keys
         ctx = account.MultiSigContext()
         # this will automatically add a witness
         acc.sign_multisig_tx(tx, password, ctx, details.network)

--- a/neo3/api/helpers/txbuilder.py
+++ b/neo3/api/helpers/txbuilder.py
@@ -69,6 +69,8 @@ class TxBuilder:
             # removing it here as it will be replaced by a proper one once we're signing
             self.tx.witnesses = []
         else:
+            if len(self.tx.signers) == 0:
+                raise ValueError("Cannot calculate network fee without signers")
             self.tx.network_fee = await self.client.calculate_network_fee(self.tx)
 
     @staticmethod


### PR DESCRIPTION
fix #260 (partially)

This PR partially fixes #260 meaning;
- it fixes signing with a `1-of-n` multi-signature account (therefore allowing to e.g. transfer genesis funds from a single consensus node like you'll find in a local development network)
- it does not fix signing with a `m-of-n` multi-signature account where `m >=2`.  I had a look at supporting this and there's quite some additional work to be done around creating multisig unsigned transactions and sharing these around. Considering open tasks in other areas this is postponed until there's an actual request for it.

