### PR TITLE
api: fix wait_for_transaction_receipt for neo-go nodes

### DIFF
--- a/neo3/api/noderpc.py
+++ b/neo3/api/noderpc.py
@@ -802,7 +802,7 @@ class RPCClient:
             asyncio.exceptions.TimeoutError
         """
         async with self.session.post(self.url, json=json) as request:
-            return await request.json()
+            return await request.json(content_type=None)
 
     async def close(self):
         """
@@ -1374,7 +1374,7 @@ class NeoRpcClient(RPCClient):
             try:
                 return await self.get_transaction_receipt(tx_hash)
             except JsonRpcError as e:
-                if "Unknown transaction" in e.message:
+                if "Unknown transaction" in e.message or "Unknown script container" in e.message:
                     await asyncio.sleep(retry_delay)
                 else:
                     raise e


### PR DESCRIPTION
1. `neo-go` nodes return a different error message when a transaction cannot be found. Which breaks the `wait_for_transaction_receipt()`  helper function. 
2. `neo-go` when asking for a transaction that does not exist (e.g. because the block is not yet processed) an error is expected. However, the neo-go nodes do not set the `content-type` of the response to `application/json` like the C# nodes do. This causes a failed content-type check during the conversion to JSON using `aiohttp`. This PR also disables content-type checking in the RPC client.