### PR TITLE
wallet: fix custom scrypt parameter usage

### DIFF
--- a/neo3/wallet/account.py
+++ b/neo3/wallet/account.py
@@ -404,7 +404,7 @@ class Account:
         if self.is_watchonly:
             raise ValueError("Cannot sign transaction using a watch only account")
         # mypy can't infer that the is_watchonly check ensures encrypted_key has a value
-        private_key = self.private_key_from_nep2(self.encrypted_key.decode("utf-8"), password)  # type: ignore
+        private_key = self.private_key_from_nep2(self.encrypted_key.decode("utf-8"), password, _scrypt_parameters=self.scrypt_parameters)  # type: ignore
         return cryptography.sign(data, private_key)
 
     @classmethod

--- a/neo3/wallet/wallet.py
+++ b/neo3/wallet/wallet.py
@@ -169,6 +169,7 @@ class Wallet(interfaces.IJson):
                     # copy key information of the first matching account
                     acc.encrypted_key = account_.encrypted_key
                     acc.public_key = account_.public_key
+                    acc.scrypt_parameters = account_.scrypt_parameters
                     break
         else:
             # scenario 2
@@ -181,6 +182,7 @@ class Wallet(interfaces.IJson):
                     if acc.public_key in public_keys:
                         account_.encrypted_key = acc.encrypted_key
                         account_.public_key = acc.public_key
+                        acc.scrypt_parameters = account_.scrypt_parameters
                         break
 
     def account_add(self, acc: account.Account, is_default=False) -> bool:


### PR DESCRIPTION
1. scrypt parameters for the `Account` instance where not taken into account when calling `sign()`. Therefore it would always assume the default scrypt parameter. This caused failures in some unittests that used custom scrypt params
2. when importing a multi-signature account the wallet will try to augment that account with the key material of the related accounts so it can be used for signing. This augmentation did not copy the scrypt parameters which could lead to the same issue as `1.`
