### PR TITLE
api: fix `Map` key processing

### DIFF
--- a/neo3/api/helpers/unwrap.py
+++ b/neo3/api/helpers/unwrap.py
@@ -147,6 +147,13 @@ def as_dict(res: noderpc.ExecutionResult, idx: int = 0) -> dict:
     Raises:
         ValueError: if the index is out of range, or the value cannot be converted to a dict.
 
+
+    Warning:
+        Accepted key types on the Virtual Machine side are `int`, `str` and `bytes`.
+        However, when data is returned there is no way to differentiate between
+        the key being of type `str` or `bytes` as the RPC node will encode both as a `ByteString`.
+        The dictionary returned will return such types as `bytes` and it is the user responsibility to decode
+        them to a `str` if needed.
     """
     return item(res, idx).as_dict()
 

--- a/neo3/api/noderpc.py
+++ b/neo3/api/noderpc.py
@@ -522,11 +522,6 @@ class ExecutionResult:
             map_ = []
             for stack_item in item["value"]:
                 key = ExecutionResult._parse_stack_item(stack_item["key"])
-                key_type = StackItemType(stack_item["key"]["type"])
-                if key_type == StackItemType.BYTE_STRING:
-                    key.value = key.value.decode()
-                else:
-                    key.value = str(key.value)
                 value = ExecutionResult._parse_stack_item(stack_item["value"])
                 map_.append((key, value))
             return MapStackItem(type_, map_)


### PR DESCRIPTION
**The problems**
1. The NEO Virtual Machine has a `Map` type which translates to a `dict` on the Python side. The keys are [restricted](https://github.com/neo-project/neo-vm/blob/ea03316ae34ca4bc7a30fd4b65dad74f1fed7e17/src/Neo.VM/Types/Map.cs#L30) to what they call `PrimitiveType`s being `Boolean` , `Integer` and `ByteString` stack item types (respectively `bool`, `int` and `str` in Python). 

    However, it is also possible to push `bytes` using the `PUSHDATA` opcodes which will be converted to a `ByteString` stack item type. Therefore we can no longer assume that when the VM returns a `ByteString` stack item that it is always a `str`. 
2. `int` key types would incorrectly be converted to `str`. 

**The solution**
This PR removes the "ByteString == `str`" assumption and also removes the `int -> str` conversion.