### PR TITLE
vm: allow pushing empty strings

### DIFF
--- a/neo3/vm.py
+++ b/neo3/vm.py
@@ -357,8 +357,6 @@ class ScriptBuilder:
                 raise ValueError("Input number exceeds maximum data size of 32 bytes")
         elif isinstance(value, (bytes, bytearray)):
             len_value = len(value)
-            if len_value == 0:
-                raise ValueError("Cannot push zero sized data")
             if len_value > 0xFFFFFFFF:
                 raise ValueError(
                     f"Value is too long {len_value}. Maximum allowed length is 0xFFFF_FFFF"

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -40,6 +40,11 @@ class ScriptBuilderTestCase(unittest.TestCase):
         expected = "0c0cd0bfd180d0b8d0b2d0b5d182"
         self.assertEqual(expected, sb.to_array().hex())
 
+        sb = vm.ScriptBuilder()
+        sb.emit_push("")
+        expected = "0c00"
+        self.assertEqual(expected, sb.to_array().hex())
+
     def test_emit_push_uint(self):
         sb = vm.ScriptBuilder()
         sb.emit_push(
@@ -125,11 +130,6 @@ class ScriptBuilderTestCase(unittest.TestCase):
         sb.emit_push(data)
         expected_header = bytes.fromhex("0e01000100")
         self.assertEqual(expected_header + data, sb.to_array())
-
-        sb = vm.ScriptBuilder()
-        with self.assertRaises(ValueError) as context:
-            sb.emit_push(b"")
-        self.assertEqual("Cannot push zero sized data", str(context.exception))
 
         # too slow
         # data = b'\x01' * (0xFFFFFFFF + 1)


### PR DESCRIPTION
@luc10921 reported that the following is allowed on the C# side
```
{ "type": "String", "value": ""  }
```

After some investigation is seems like the `ScriptBuilder` simply ignores the value and does not add anything to the stream. It will only push `OpCode.PUSHDATA1` and a length `0` to the byte array. This PR fixes this scenario to also accept empty strings 