### PR TITLE
api: disable IPv6 in RpcClient

### DIFF
--- a/neo3/api/noderpc.py
+++ b/neo3/api/noderpc.py
@@ -802,7 +802,7 @@ class RPCClient:
         self.timeout = timeout
         self.session = aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=self.timeout),
-            connector=aiohttp.TCPConnector(family=socket.AF_INET)
+            connector=aiohttp.TCPConnector(family=socket.AF_INET),
         )
 
     async def _post(self, json: dict):

--- a/neo3/api/noderpc.py
+++ b/neo3/api/noderpc.py
@@ -2,6 +2,9 @@
 NEO RPC Node client and response classes.
 """
 from __future__ import annotations
+
+import socket
+
 import aiohttp
 import base64
 import asyncio
@@ -798,7 +801,8 @@ class RPCClient:
         self.url = url
         self.timeout = timeout
         self.session = aiohttp.ClientSession(
-            timeout=aiohttp.ClientTimeout(total=self.timeout)
+            timeout=aiohttp.ClientTimeout(total=self.timeout),
+            connector=aiohttp.TCPConnector(family=socket.AF_INET)
         )
 
     async def _post(self, json: dict):


### PR DESCRIPTION
There is an issue with Windows that when it has IPv6 enabled and the RpcClient makes a call on a route that is not fully IPv6 it will take a long time to timeout before falling back to IPv4. This caused HUGE delays with boa-test-constructor.

This PR forces the usage of IPv4. 