### PR TITLE
api: do not throw on VM FAULT in `calculate_system_fee()`

### DIFF
--- a/neo3/api/helpers/txbuilder.py
+++ b/neo3/api/helpers/txbuilder.py
@@ -45,8 +45,6 @@ class TxBuilder:
                 "fee calculation will be incorrect"
             )
         res = await self.client.invoke_script(self.tx.script, self.tx.signers)
-        if res.state != "HALT":
-            raise ValueError(f"Failed to get system fee: {res.exception}")
         self.tx.system_fee = res.gas_consumed
 
     async def set_valid_until_block(self) -> None:


### PR DESCRIPTION
It is not the job of `calculate_system_fee` to say something about the correctness of the script in the transaction. One scenario where the current behaviour is problematic is testing for expected assertion errors with the boa test framework.