### PR TITLE
api: increase receipt timeout value fetching to fix `Windows` loop time inaccuracy

### DIFF
--- a/neo3/api/wrappers.py
+++ b/neo3/api/wrappers.py
@@ -615,7 +615,7 @@ class ChainFacade:
                     result.protocol.ms_per_block / 1000
                 ) / 5
                 timeout = self._receipt_timeout = (
-                    result.protocol.ms_per_block / 1000
+                    (result.protocol.ms_per_block / 1000) * 2
                 ) + self._receipt_retry_delay
                 return delay, timeout
         else:


### PR DESCRIPTION
The timeout logic in ba2bf07079dc28696203d439333ea098350c5430 turned out to be too tight for Windows. This increases the timeout to solve that.