### PR TITLE
setup: make PEP-561 compliant

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,6 +8,7 @@ graft docs/*
 include docs/make.bat
 include docs/Makefile
 recursive-exclude docs/build/*
+include neo3/py.typed
 graft neo3/*
 graft tests/*
 global-exclude *.py[cod]


### PR DESCRIPTION
Ensure consumers of the package can use tools like `mypy` without getting warnings such as
```shell
Skipping analyzing "neo3.wallet": module is installed, but missing library stubs or py.typed marker  [import-untyped]
```