### PR TITLE
Bump aiohttp from 3.8.5 to 3.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "aioresponses==0.7.4",
+    "aioresponses==0.7.6",
     "black==23.9.1",
     "build==0.10.0",
     "bump-my-version==0.10.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ maintainers = [
 dynamic = ["version"]
 dependencies = [
     "aiodns==3.0.0",
-    "aiohttp==3.8.5",
+    "aiohttp==3.9.1",
     "base58==2.1.1",
     "bitarray==2.8.1",
     "Events==0.5",


### PR DESCRIPTION
Dependabot has [upgraded](https://github.com/nspcc-dev/neofs-testcases/pull/674) aiohttp in the neofs-testcases project, and since we use neo-mamba as a dependency, we would like to fix the version conflict by upgrading aiohttp to the latest version.

