### PR TITLE
api: add `tokens_count` method to NEP11Contract

### DIFF
--- a/neo3/api/wrappers.py
+++ b/neo3/api/wrappers.py
@@ -1227,6 +1227,18 @@ class _NEP11Contract(_TokenContract):
         )
         return ContractMethodResult(sb.to_array(), process)
 
+    def tokens_count(self):
+        """
+        Count all tokens minted by the contract
+
+        Note:
+            This depends on the optional `tokens` method and can thus fail.
+        """
+        sb = vm.ScriptBuilder().emit_contract_call_and_count_iterator(
+            self.hash, "tokens"
+        )
+        return ContractMethodResult(sb.to_array(), unwrap.as_int)
+
     def properties(self, token_id: bytes) -> ContractMethodResult[dict]:
         """
         Get all properties for the given NFT.


### PR DESCRIPTION
NEP-11 defines an optional `tokens` method. the `NEP11Contract` wraps this method and manually unwraps the iterator such that it does not have to rely on RPC servers that have iterator sessions enabled (which many don't). However, that means there's a ~2000 item limit on the return. This helper is part 1 to resolve that limit.

Part 2 will allow defining a start index into the iterator. Combining both allows us to query all items using a while or for loop.