### PR TITLE
vm: fix order when pushing dictionaries with `ScriptBuilder`

### DIFF
--- a/neo3/vm.py
+++ b/neo3/vm.py
@@ -402,7 +402,7 @@ class ScriptBuilder:
             self.emit(OpCode.PACK)
             return self
         elif isinstance(value, dict):
-            for k, v in value.items():
+            for k, v in reversed(value.items()):
                 # This restriction exists on the VM side where keys to a 'Map' may only be of 'PrimitiveType'
                 if not isinstance(
                     k, (int, str, bool, bytes, serialization.ISerializable)

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -143,13 +143,13 @@ class ScriptBuilderTestCase(unittest.TestCase):
 
         sb = vm.ScriptBuilder()
         sb.emit_push(data)
-        expected = "007b0c016101c8010c016212be"
+        expected = "01c8010c0162007b0c016112be"
         self.assertEqual(expected, sb.to_array().hex())
 
         data = {b"\x01": 1, b"\x02": 2}
         sb = vm.ScriptBuilder()
         sb.emit_push(data)
-        expected = "110c0101120c010212be"
+        expected = "120c0102110c010112be"
         self.assertEqual(expected, sb.to_array().hex())
 
         # test invalid key type


### PR DESCRIPTION
Based on feedback from @luc10921 while writing Boa tests. Order should be reversed just like we do for Sequences