### PR TITLE
api: fix type error when contract state not found

### DIFF
--- a/neo3/api/noderpc.py
+++ b/neo3/api/noderpc.py
@@ -930,7 +930,7 @@ class NeoRpcClient(RPCClient):
             response = await self._do_post(
                 "findstorage", [contract_hash, _prefix, start]
             )
-            if response["results"]:
+            if response["results"] is not None:
                 for pair in response["results"]:
                     key = base64.b64decode(pair["key"])
                     value = base64.b64decode(pair["value"])

--- a/neo3/api/noderpc.py
+++ b/neo3/api/noderpc.py
@@ -930,10 +930,11 @@ class NeoRpcClient(RPCClient):
             response = await self._do_post(
                 "findstorage", [contract_hash, _prefix, start]
             )
-            for pair in response["results"]:
-                key = base64.b64decode(pair["key"])
-                value = base64.b64decode(pair["value"])
-                yield key, value
+            if response["results"]:
+                for pair in response["results"]:
+                    key = base64.b64decode(pair["key"])
+                    value = base64.b64decode(pair["value"])
+                    yield key, value
             if not response["truncated"]:
                 break
             start = response["next"]

--- a/tests/api/test_noderpc.py
+++ b/tests/api/test_noderpc.py
@@ -706,6 +706,14 @@ class TestNeoRpcClient(unittest.IsolatedAsyncioTestCase):
         self.assertIn("bogus_message", str(context.exception))
         self.assertIn("bogus_data", str(context.exception))
 
+    async def test_findstorage_issue_neogo(self):
+        # test workaround for https://github.com/nspcc-dev/neo-go/issues/3370
+        captured = {"results": None, "next": 0, "truncated": False}
+        self.mock_response(captured)
+
+        x = [(k, v) async for k, v in self.client.find_states(types.UInt160.zero())]
+        self.assertEqual(0, len(x))
+
 
 class TestStackItem(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
When contract state is not found the results in response returns None, because of this interactions using `find_states` result  fail with TypeError (since None cannot be iterated)