### PR TITLE
docs: fix various typos in docstrings

### DIFF
--- a/neo3/api/helpers/txbuilder.py
+++ b/neo3/api/helpers/txbuilder.py
@@ -55,7 +55,7 @@ class TxBuilder:
 
     async def calculate_network_fee(self) -> None:
         """
-        Calculates and set the system fee. Requires at least one signer.
+        Calculate and set the network fee. Requires at least one signer.
         """
         if len(self.tx.witnesses) == 0:
             if len(self.tx.signers) == 0:

--- a/neo3/api/helpers/unwrap.py
+++ b/neo3/api/helpers/unwrap.py
@@ -116,7 +116,7 @@ def as_public_key(res: noderpc.ExecutionResult, idx: int = 0) -> cryptography.EC
         idx: the index in the result stack to fetch the stack item from.
 
     Raises:
-        ValueError: if the index is out of range, or the value cannot be converted to a bool.
+        ValueError: if the index is out of range, or the value cannot be converted to an ECPoint.
         ECCException: if the resulting key is not valid on the SECP256R1 curve.
     """
     return item(res, idx).as_public_key()

--- a/neo3/api/wrappers.py
+++ b/neo3/api/wrappers.py
@@ -463,7 +463,7 @@ class ChainFacade:
             append_system_fee: increase the calculated system fee with this amount.
 
         Returns:
-            a list with the results of all exected functions.
+            a list with the results of all executed functions.
 
         See Also:
             `test_invoke_multi` - free equivalent for read only operations or testing.
@@ -525,7 +525,7 @@ class ChainFacade:
             append_system_fee: increase the calculated system fee with this amount.
 
         Returns:
-            a transaction ID if accepted by the network. Acceptance is does not guarantee successful execution.
+            a transaction ID if accepted by the network. Acceptance does not guarantee successful execution.
             Acceptance means there are no transaction format errors. Use `invoke()` to wait for a receipt. The `state`
             field of the receipt indicates if the transaction script executed successfully.
 
@@ -575,7 +575,7 @@ class ChainFacade:
             append_system_fee: increase the calculated system fee with this amount.
 
         Returns:
-            a list with the results of all exected functions.
+            a list with the results of all executed functions.
 
         See Also:
             `test_invoke_raw` - free equivalent for read only operations or testing.
@@ -623,7 +623,7 @@ class ChainFacade:
 
     def add_signer(self, func: signing.SigningFunction, signer: verification.Signer):
         """
-        Add a `Signer` which will automatically be included when the various invoke functions.
+        Add a `Signer` that will automatically be included when the various invoke* functions are called.
         """
         self._signing_funcs.append(func)
         self.signers.append(signer)

--- a/neo3/contracts/utils.py
+++ b/neo3/contracts/utils.py
@@ -1,5 +1,5 @@
 """
-Contract utilities for determing the contract hash, contract types, extracting public keys and signing treshold and more.
+Contract utilities for determining the contract hash, contract types, extracting public keys and signing threshold and more.
 """
 from typing import Type
 from collections.abc import Sequence


### PR DESCRIPTION
chore