### PR TITLE
api: extend `get_version` RPC call with extra fields

### DIFF
--- a/neo3/api/noderpc.py
+++ b/neo3/api/noderpc.py
@@ -91,6 +91,7 @@ class VersionProtocol:
     max_valid_until_block_increment: int
     memorypool_max_transactions: int
     initial_gas_distribution: int
+    hardforks: dict[str, int]
 
 
 @dataclass
@@ -104,10 +105,17 @@ class GetVersionResponse:
     nonce: int
     user_agent: str
     protocol: VersionProtocol
+    rpc_session_enabled: bool
+    rpc_max_iterator_results: int
 
     @classmethod
     def from_json(cls, json: dict):
         p = json["protocol"]
+
+        hf = {}
+        for pair in p["hardforks"]:
+            hf.update({pair["name"]:pair["blockheight"]})
+
         vp = VersionProtocol(
             p["addressversion"],
             p["network"],
@@ -118,6 +126,7 @@ class GetVersionResponse:
             p["maxvaliduntilblockincrement"],
             p["memorypoolmaxtransactions"],
             p["initialgasdistribution"],
+            hf
         )
         wsport = json.get("wsport", None)
         return cls(
@@ -126,6 +135,8 @@ class GetVersionResponse:
             json["nonce"],
             json["useragent"],
             vp,
+            json["rpc"]["sessionenabled"],
+            json["rpc"]["maxiteratorresultitems"]
         )
 
 

--- a/neo3/api/noderpc.py
+++ b/neo3/api/noderpc.py
@@ -114,7 +114,7 @@ class GetVersionResponse:
 
         hf = {}
         for pair in p["hardforks"]:
-            hf.update({pair["name"]:pair["blockheight"]})
+            hf.update({pair["name"]: pair["blockheight"]})
 
         vp = VersionProtocol(
             p["addressversion"],
@@ -126,7 +126,7 @@ class GetVersionResponse:
             p["maxvaliduntilblockincrement"],
             p["memorypoolmaxtransactions"],
             p["initialgasdistribution"],
-            hf
+            hf,
         )
         wsport = json.get("wsport", None)
         return cls(
@@ -136,7 +136,7 @@ class GetVersionResponse:
             json["useragent"],
             vp,
             json["rpc"]["sessionenabled"],
-            json["rpc"]["maxiteratorresultitems"]
+            json["rpc"]["maxiteratorresultitems"],
         )
 
 

--- a/tests/api/test_noderpc.py
+++ b/tests/api/test_noderpc.py
@@ -558,6 +558,10 @@ class TestNeoRpcClient(unittest.IsolatedAsyncioTestCase):
             "wsport": 10334,
             "nonce": 1930156121,
             "useragent": user_agent,
+            "rpc": {
+                "maxiteratorresultitems": 100,
+                "sessionenabled": True
+            },
             "protocol": {
                 "addressversion": 53,
                 "network": 860833102,
@@ -568,6 +572,24 @@ class TestNeoRpcClient(unittest.IsolatedAsyncioTestCase):
                 "maxtransactionsperblock": 512,
                 "memorypoolmaxtransactions": 50000,
                 "initialgasdistribution": 5200000000000000,
+                "hardforks": [
+                    {
+                        "name": "Aspidochelone",
+                        "blockheight": 1730000
+                    },
+                    {
+                        "name": "Basilisk",
+                        "blockheight": 4120000
+                    },
+                    {
+                        "name": "Cockatrice",
+                        "blockheight": 5450000
+                    },
+                    {
+                        "name": "Domovoi",
+                        "blockheight": 5570000
+                    }
+                ]
             },
         }
         self.mock_response(captured)

--- a/tests/api/test_noderpc.py
+++ b/tests/api/test_noderpc.py
@@ -558,10 +558,7 @@ class TestNeoRpcClient(unittest.IsolatedAsyncioTestCase):
             "wsport": 10334,
             "nonce": 1930156121,
             "useragent": user_agent,
-            "rpc": {
-                "maxiteratorresultitems": 100,
-                "sessionenabled": True
-            },
+            "rpc": {"maxiteratorresultitems": 100, "sessionenabled": True},
             "protocol": {
                 "addressversion": 53,
                 "network": 860833102,
@@ -573,23 +570,11 @@ class TestNeoRpcClient(unittest.IsolatedAsyncioTestCase):
                 "memorypoolmaxtransactions": 50000,
                 "initialgasdistribution": 5200000000000000,
                 "hardforks": [
-                    {
-                        "name": "Aspidochelone",
-                        "blockheight": 1730000
-                    },
-                    {
-                        "name": "Basilisk",
-                        "blockheight": 4120000
-                    },
-                    {
-                        "name": "Cockatrice",
-                        "blockheight": 5450000
-                    },
-                    {
-                        "name": "Domovoi",
-                        "blockheight": 5570000
-                    }
-                ]
+                    {"name": "Aspidochelone", "blockheight": 1730000},
+                    {"name": "Basilisk", "blockheight": 4120000},
+                    {"name": "Cockatrice", "blockheight": 5450000},
+                    {"name": "Domovoi", "blockheight": 5570000},
+                ],
             },
         }
         self.mock_response(captured)


### PR DESCRIPTION
Add new available fields
- hardforks
- RPC iterator enabled
- RPC iterator max results