### PR TITLE
vm: add `ABORTMSG` & `ASSERTMSG` opcodes

### DIFF
--- a/neo3/vm.py
+++ b/neo3/vm.py
@@ -241,6 +241,8 @@ class OpCode(IntEnum):
     ISNULL = 0xD8
     ISTYPE = 0xD9
     CONVERT = 0xDB
+    ABORTMSG = 0xE0
+    ASSERTMSG = 0xE1
 
     def __eq__(self, other):
         if super(OpCode, self).__eq__(other) is True:


### PR DESCRIPTION
I somehow forgot to add the opcodes for my [own PR](https://github.com/neo-project/neo-vm/pull/491) on the VM.