### PR TITLE
api: do not post process on VM exception in test_invoke

### DIFF
--- a/neo3/api/wrappers.py
+++ b/neo3/api/wrappers.py
@@ -235,7 +235,7 @@ class ChainFacade:
         """
         async with noderpc.NeoRpcClient(self.rpc_host) as client:
             res = await client.invoke_script(f.script, signers)
-            if f.execution_processor is None or return_raw:
+            if f.execution_processor is None or return_raw or res.state != "HALT":
                 return res
             return f.execution_processor(res, 0)
 


### PR DESCRIPTION
If a test invoke ends in a VMFault state we should not attempt to post process the results as the result stack likely does not contain what is necessary.