### PR TITLE
api, tests: streamline invoke return types

### DIFF
--- a/examples/contract-deploy-update-destroy.py
+++ b/examples/contract-deploy-update-destroy.py
@@ -38,8 +38,8 @@ async def main(neoxp: shared.NeoExpress):
     contract = GenericContract(contract_hash)
     print("Calling `add` with input 1, result is: ", end="")
     # using test_invoke here because we don't really care about the result being persisted to the chain
-    result = await facade.test_invoke(contract.call_function("add", [1]))
-    print(unwrap.as_int(result))
+    receipt = await facade.test_invoke(contract.call_function("add", [1]))
+    print(unwrap.as_int(receipt.result))
 
     print("Updating contract with version 2...", end="")
     nef_v2 = nef.NEF.from_file(files_path + "contract_v2.nef")
@@ -52,8 +52,8 @@ async def main(neoxp: shared.NeoExpress):
 
     print("Calling `add` with input 1, result is: ", end="")
     # Using test_invoke here because we don't really care about the result being persisted to the chain
-    result = await facade.test_invoke(contract.call_function("add", [1]))
-    print(unwrap.as_int(result))
+    receipt = await facade.test_invoke(contract.call_function("add", [1]))
+    print(unwrap.as_int(receipt.result))
 
     print("Destroying contract...", end="")
     # destroy also doesn't give any return value. So if it doesn't fail then it means success

--- a/examples/nep-11-airdrop.py
+++ b/examples/nep-11-airdrop.py
@@ -21,8 +21,8 @@ async def example_airdrop(neoxp: shared.NeoExpress):
 
     # Wrap the NFT contract
     ntf = NEP11NonDivisibleContract(shared.nep11_token_hash)
-    balance = len(await facade.test_invoke(ntf.token_ids_owned_by(account.address)))
-    print(f"Current NFT balance: {balance}")
+    receipt = await facade.test_invoke(ntf.token_ids_owned_by(account.address))
+    print(f"Current NFT balance: {len(receipt.result)}")
 
     # First we have to mint the NFTs to our own wallet
     # We do this by sending 10 GAS to the contract. We do this in 2 separate transactions because the NFT is
@@ -47,7 +47,8 @@ async def example_airdrop(neoxp: shared.NeoExpress):
         )
     )
     print(receipt.result)
-    token_ids = await facade.test_invoke(ntf.token_ids_owned_by(account.address))
+    receipt = await facade.test_invoke(ntf.token_ids_owned_by(account.address))
+    token_ids = receipt.result
     print(f"New NFT token balance: {len(token_ids)}, ids: {token_ids}")
 
     # Now let's airdrop the NFTs

--- a/examples/nep17-airdrop.py
+++ b/examples/nep17-airdrop.py
@@ -23,8 +23,8 @@ async def example_airdrop(neoxp: shared.NeoExpress):
 
     # Use the generic NEP17 class to wrap the token
     token = NEP17Contract(shared.coz_token_hash)
-    balance = await facade.test_invoke(token.balance_of(account.address))
-    print(f"Current COZ token balance: {balance}")
+    receipt = await facade.test_invoke(token.balance_of(account.address))
+    print(f"Current COZ token balance: {receipt.result}")
 
     # First we have to mint the tokens to our own wallet
     # We do this by sending NEO to the contract
@@ -46,8 +46,8 @@ async def example_airdrop(neoxp: shared.NeoExpress):
 
     print(receipt.result)
 
-    balance = await facade.test_invoke(token.balance_of(account.address))
-    print(f"New COZ token balance: {balance}")
+    receipt = await facade.test_invoke(token.balance_of(account.address))
+    print(f"New COZ token balance: {receipt.result}")
 
     # Now let's airdrop the tokens
     destination_addresses = [

--- a/examples/nep17-transfer.py
+++ b/examples/nep17-transfer.py
@@ -42,7 +42,7 @@ async def example_transfer_other(neoxp: shared.NeoExpress):
     facade = ChainFacade(rpc_host=neoxp.rpc_host)
     facade.add_signer(
         sign_insecure_with_account(account, password="123"),
-        Signer(account.script_hash),  # default scope is CALLED_BY_ENTRY
+        Signer(account.script_hash),  # default scope is te/CALLED_BY_ENTRY
     )
 
     source = account.address

--- a/examples/vote.py
+++ b/examples/vote.py
@@ -22,7 +22,8 @@ async def example_vote(neoxp: shared.NeoExpress):
     # Dedicated Neo native contract wrapper
     neo = NeoToken()
     # get a list of candidates that can be voted on
-    candidates = await facade.test_invoke(neo.candidates_registered())
+    receipt = await facade.test_invoke(neo.candidates_registered())
+    candidates = receipt.result
     # the example chain only has 1 candidate, use that
     candidate_pk = candidates[0].public_key
 


### PR DESCRIPTION
Currently all `test_*` functions of `ChainFacade` directly return the actual result of the called method on the smart contract. Which is very convenient when only using test invokes, but makes it inconvenient when switching between `invoke_` and `test_invoke` because now the return type changed. 

Personally when writing code that ends up persisting to chain (via `invoke`) I start off with `test_invoke` (also with debugging) before swapping it over. By streamlining the return types one does not have to change the result handling code.

Changes in this PR
- all `test_invoke*` now return an `InvokeReceipt` just like regular `invoke*` calls
- `invoke_multi` and `invoke_multi_raw` return `InvokeReceipt[Sequence]` instead of `Sequence`