### PR TITLE
api: expose `NeoRpcClient` on `ChainFacade`

### DIFF
--- a/neo3/api/wrappers.py
+++ b/neo3/api/wrappers.py
@@ -146,6 +146,7 @@ class ChainFacade:
             receipt_timeout: maximum time to wait in seconds to find the transaction on the chain.
         """
         self.rpc_host = rpc_host
+        self.client = noderpc.NeoRpcClient(rpc_host)
         self._signing_func = None
         self.network = -1
         self.address_version = -1

--- a/neo3/api/wrappers.py
+++ b/neo3/api/wrappers.py
@@ -146,7 +146,7 @@ class ChainFacade:
             receipt_timeout: maximum time to wait in seconds to find the transaction on the chain.
         """
         self.rpc_host = rpc_host
-        self.client = noderpc.NeoRpcClient(rpc_host)
+        self.rpc_client = noderpc.NeoRpcClient(rpc_host)
         self._signing_func = None
         self.network = -1
         self.address_version = -1


### PR DESCRIPTION
I so often miss this when I'm working with the facade and then decide I want to query something directly over RPC (e.g. `getversion`) and then have to create a separate client with matching host etc.