### PR TITLE
ci: resolve workflow deprecation warnings

### DIFF
--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -16,9 +16,9 @@ jobs:
   deploy-pypi:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4.6.1
+        uses: actions/setup-python@v5.2.0
         with:
           python-version: '3.11'
       - name: Create dist
@@ -44,7 +44,7 @@ jobs:
           twine upload --repository testpypi dist/*
       - if: github.event.inputs.pypi-target == 'Main' || github.event_name == 'push'
         name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/validate-pr-commit.yml
+++ b/.github/workflows/validate-pr-commit.yml
@@ -18,11 +18,11 @@ jobs:
         python-version: ["3.11", "3.12"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: 'mamba'
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4.6.1
+        uses: actions/setup-python@v5.2.0
         with:
           python-version: ${{ matrix.python-version }}
           check-latest: true
@@ -43,7 +43,7 @@ jobs:
       - name: prep for persist
         run: tar -czf mamba.tar.gz mamba
       - name: persist
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: setup-artifact-${{ matrix.os }}-py${{ matrix.python-version }}
           path: mamba.tar.gz
@@ -51,7 +51,7 @@ jobs:
   linting:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: psf/black@stable
         with:
           options: '--check --target-version py311'
@@ -62,11 +62,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: restore artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: setup-artifact-ubuntu-20.04-py3.11
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4.6.1
+        uses: actions/setup-python@v5.2.0
         with:
           python-version: "3.11"
           check-latest: true
@@ -86,11 +86,11 @@ jobs:
         python-version: ["3.11", "3.12"]
     steps:
       - name: restore artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: setup-artifact-${{ matrix.os }}-py${{ matrix.python-version }}
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4.6.1
+        uses: actions/setup-python@v5.2.0
         with:
           python-version: '${{ matrix.python-version }}'
           check-latest: true
@@ -115,11 +115,11 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: restore artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: setup-artifact-ubuntu-20.04-py3.11
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4.6.1
+        uses: actions/setup-python@v5.2.0
         with:
           python-version: "3.11"
           check-latest: true


### PR DESCRIPTION
All warnings were about the usage of old nodejs versions in the actions used. Updating the actions to the latest versions should resolve this.