### PR TITLE
wallet: change Account/Wallet password handling

### DIFF
--- a/examples/contract-deploy-update-destroy.py
+++ b/examples/contract-deploy-update-destroy.py
@@ -6,7 +6,7 @@ Finally, the contract is destroyed.
 
 import asyncio
 from neo3.api.wrappers import GenericContract, ChainFacade
-from neo3.api.helpers.signing import sign_insecure_with_account
+from neo3.api.helpers.signing import sign_with_account
 from neo3.api.helpers import unwrap
 from neo3.contracts import nef, manifest
 from neo3.network.payloads.verification import Signer
@@ -20,7 +20,7 @@ async def main(neoxp: shared.NeoExpress):
     # This is your interface for talking to the blockchain
     facade = ChainFacade(rpc_host=neoxp.rpc_host)
     facade.add_signer(
-        sign_insecure_with_account(account, password="123"),
+        sign_with_account(account),
         Signer(account.script_hash),  # default scope is CALLED_BY_ENTRY
     )
 

--- a/examples/nep-11-airdrop.py
+++ b/examples/nep-11-airdrop.py
@@ -3,7 +3,7 @@ This example shows how to send NFTs to multiple accounts in one go (airdrop).
 """
 import asyncio
 from neo3.api.wrappers import ChainFacade, GasToken, NEP11NonDivisibleContract
-from neo3.api.helpers.signing import sign_insecure_with_account
+from neo3.api.helpers.signing import sign_with_account
 from neo3.network.payloads.verification import Signer
 from examples import shared
 
@@ -15,7 +15,7 @@ async def example_airdrop(neoxp: shared.NeoExpress):
     # This is your interface for talking to the blockchain
     facade = ChainFacade(rpc_host=neoxp.rpc_host)
     facade.add_signer(
-        sign_insecure_with_account(account, password="123"),
+        sign_with_account(account),
         Signer(account.script_hash),  # default scope is CALLED_BY_ENTRY
     )
 

--- a/examples/nep17-airdrop.py
+++ b/examples/nep17-airdrop.py
@@ -4,7 +4,7 @@ It will mint the "COZ Token"
 """
 import asyncio
 from neo3.api.wrappers import ChainFacade, NeoToken, NEP17Contract
-from neo3.api.helpers.signing import sign_insecure_with_account
+from neo3.api.helpers.signing import sign_with_account
 from neo3.network.payloads.verification import Signer
 from examples import shared
 
@@ -17,7 +17,7 @@ async def example_airdrop(neoxp: shared.NeoExpress):
     # This is your interface for talking to the blockchain
     facade = ChainFacade(rpc_host=neoxp.rpc_host)
     facade.add_signer(
-        sign_insecure_with_account(account, password="123"),
+        sign_with_account(account),
         Signer(account.script_hash),  # default scope is CALLED_BY_ENTRY
     )
 

--- a/examples/nep17-transfer.py
+++ b/examples/nep17-transfer.py
@@ -5,7 +5,7 @@ implements the NEP-17 standard
 """
 import asyncio
 from neo3.api.wrappers import ChainFacade, NeoToken, NEP17Contract
-from neo3.api.helpers.signing import sign_insecure_with_account
+from neo3.api.helpers.signing import sign_with_account
 from neo3.network.payloads.verification import Signer
 from neo3.core import types
 from examples import shared
@@ -19,7 +19,7 @@ async def example_transfer_neo(neoxp: shared.NeoExpress):
     # This is your interface for talking to the blockchain
     facade = ChainFacade(rpc_host=neoxp.rpc_host)
     facade.add_signer(
-        sign_insecure_with_account(account, password="123"),
+        sign_with_account(account),
         Signer(account.script_hash),  # default scope is CALLED_BY_ENTRY
     )
 
@@ -41,7 +41,7 @@ async def example_transfer_other(neoxp: shared.NeoExpress):
     # This is your interface for talking to the blockchain
     facade = ChainFacade(rpc_host=neoxp.rpc_host)
     facade.add_signer(
-        sign_insecure_with_account(account, password="123"),
+        sign_with_account(account),
         Signer(account.script_hash),  # default scope is te/CALLED_BY_ENTRY
     )
 

--- a/examples/vote.py
+++ b/examples/vote.py
@@ -3,7 +3,7 @@ This example shows how to vote for your favourite consensus node
 """
 import asyncio
 from neo3.api.wrappers import ChainFacade, NeoToken
-from neo3.api.helpers.signing import sign_insecure_with_account
+from neo3.api.helpers.signing import sign_with_account
 from neo3.network.payloads.verification import Signer
 from examples import shared
 
@@ -15,7 +15,7 @@ async def example_vote(neoxp: shared.NeoExpress):
     # This is your interface for talking to the blockchain
     facade = ChainFacade(rpc_host=neoxp.rpc_host)
     facade.add_signer(
-        sign_insecure_with_account(account, password="123"),
+        sign_with_account(account),
         Signer(account.script_hash),
     )
 

--- a/neo3/api/helpers/signing.py
+++ b/neo3/api/helpers/signing.py
@@ -20,7 +20,7 @@ class SigningDetails:
 SigningFunction = Callable[[transaction.Transaction, SigningDetails], Awaitable]
 
 
-def sign_insecure_with_account(acc: account.Account, password: str) -> SigningFunction:
+def sign_with_account(acc: account.Account) -> SigningFunction:
     """
     Sign and add a witness using the account and the provided account password.
     """
@@ -29,28 +29,12 @@ def sign_insecure_with_account(acc: account.Account, password: str) -> SigningFu
         tx: transaction.Transaction, details: SigningDetails
     ):
         # this will automatically add a witness
-        acc.sign_tx(tx, password, details.network)
+        acc.sign_tx(tx, details.network)
 
     return insecure_account_signer
 
 
-def sign_secure_with_account(
-    acc: account.Account, env_password_name: str
-) -> SigningFunction:
-    """
-    Sign and add a witness using the account. The account password is read from the environment variables.
-    """
-
-    async def insecure_account_signer(
-        tx: transaction.Transaction, details: SigningDetails
-    ):
-        # this will automatically add a witness
-        acc.sign_tx(tx, os.environ[env_password_name], details.network)
-
-    return insecure_account_signer
-
-
-def sign_secure_with_ledger() -> SigningFunction:
+def sign_with_ledger() -> SigningFunction:
     raise NotImplementedError
 
 

--- a/neo3/api/helpers/signing.py
+++ b/neo3/api/helpers/signing.py
@@ -49,9 +49,7 @@ def sign_on_remote_server() -> SigningFunction:
     return remote_server_signer
 
 
-def sign_insecure_with_multisig_account(
-    acc: account.Account, password: str
-) -> SigningFunction:
+def sign_with_multisig_account(acc: account.Account) -> SigningFunction:
     """
     Sign and add a multi-signature witness.
 
@@ -59,7 +57,6 @@ def sign_insecure_with_multisig_account(
 
     Args:
         acc: a multi-signature account
-        password: the password of the account to sign with
     """
 
     async def insecure_account_signer(
@@ -67,7 +64,7 @@ def sign_insecure_with_multisig_account(
     ):
         ctx = account.MultiSigContext()
         # this will automatically add a witness
-        acc.sign_multisig_tx(tx, password, ctx, details.network)
+        acc.sign_multisig_tx(tx, ctx, details.network)
 
     return insecure_account_signer
 

--- a/neo3/api/helpers/txbuilder.py
+++ b/neo3/api/helpers/txbuilder.py
@@ -77,7 +77,7 @@ class TxBuilder:
     @staticmethod
     def _dummy_signing_witness() -> verification.Witness:
         """single signature account witness"""
-        acc = account.Account.create_new("abc")
+        acc = account.Account.create_new()
         if acc.contract is None:
             raise Exception(
                 "Unreachable"

--- a/neo3/api/wrappers.py
+++ b/neo3/api/wrappers.py
@@ -146,7 +146,7 @@ class ChainFacade:
             receipt_timeout: maximum time to wait in seconds to find the transaction on the chain.
         """
         self.rpc_host = rpc_host
-        self._rpc_client = None
+        self._rpc_client: Optional[noderpc.NeoRpcClient] = None
         self._signing_func = None
         self.network = -1
         self.address_version = -1

--- a/neo3/wallet/account.py
+++ b/neo3/wallet/account.py
@@ -161,7 +161,6 @@ class Account:
 
     def __init__(
         self,
-        password: Optional[str] = None,
         private_key: Optional[bytes] = None,
         watch_only: bool = False,
         address: Optional[NeoAddress] = None,
@@ -172,11 +171,10 @@ class Account:
         scrypt_parameters: Optional[scrypt.ScryptParameters] = None,
     ):
         """
-        Instantiate an account. This constructor should only be directly called when it's desired to create a new
-        account using just a password and a randomly generated private key, otherwise use the alternative constructors.
+        Instantiate an account. This constructor should only be called directly when it's desired to create a new
+        account with a randomly generated private key, otherwise use the alternative constructors.
         """
         public_key: Optional[cryptography.ECPoint] = None
-        encrypted_key: Optional[bytes] = None
         contract_script: Optional[bytes] = None
 
         if watch_only:
@@ -184,23 +182,15 @@ class Account:
                 raise ValueError("Creating a watch only account requires an address")
             else:
                 utils.validate_address(address)
-
         else:
-            if not watch_only and password is None:
-                raise ValueError(
-                    "Can't create an account without a password unless it is a watch only account. "
-                    "To create a watch only accont set `watch_only` to `True` and provide an address"
-                )
             key_pair: cryptography.KeyPair
 
             if private_key is None:
                 key_pair = cryptography.KeyPair.generate()
-                private_key = key_pair.private_key
+                self.private_key = key_pair.private_key
             else:
                 key_pair = cryptography.KeyPair(private_key)
-            encrypted_key = self.private_key_to_nep2(
-                private_key, password, scrypt_parameters
-            )
+                self.private_key = private_key
             contract_script = contractutils.create_signature_redeemscript(
                 key_pair.public_key
             )
@@ -211,7 +201,6 @@ class Account:
         self.label: Optional[str] = label
         self.address: NeoAddress = address
         self.public_key = public_key
-        self.encrypted_key = encrypted_key
         self.lock = lock
         self.scrypt_parameters = scrypt_parameters
 
@@ -242,7 +231,7 @@ class Account:
         """
         Return if the account can only be used for observing or in test transactions.
         """
-        if self.encrypted_key is None:
+        if self.private_key is None:
             return True
         else:
             return False
@@ -282,14 +271,13 @@ class Account:
         tx.signers.insert(0, verification.Signer(self.script_hash, scope))
 
     def sign_tx(
-        self, tx: transaction.Transaction, password: str, magic: Optional[int] = None
+        self, tx: transaction.Transaction, magic: Optional[int] = None
     ) -> None:
         """
         Helper function that signs the TX, adds the Witness and Sender.
 
         Args:
             tx: transaction to sign.
-            password: the password to decrypt the private key for signing.
             magic: the network magic.
 
         Raises:
@@ -303,7 +291,7 @@ class Account:
         message = (
             magic.to_bytes(4, byteorder="little", signed=False) + tx.hash().to_array()
         )
-        signature = self.sign(message, password)
+        signature = self.sign(message)
 
         invocation_script = vm.ScriptBuilder().emit_push(signature).to_array()
         # mypy can't infer that the is_watchonly check ensures public_key has a value
@@ -315,7 +303,6 @@ class Account:
     def sign_multisig_tx(
         self,
         tx: transaction.Transaction,
-        password: str,
         context: MultiSigContext,
         magic: Optional[int] = None,
     ) -> None:
@@ -324,7 +311,6 @@ class Account:
 
         Args:
             tx: the transaction to sign.
-            password: account password.
             context: the signing context.
             magic: override network magic.
         """
@@ -364,7 +350,7 @@ class Account:
         message = (
             magic.to_bytes(4, byteorder="little", signed=False) + tx.hash().to_array()
         )
-        signature = self.sign(message, password)
+        signature = self.sign(message)
 
         context.signature_pairs.update({self.public_key: signature})
 
@@ -390,40 +376,34 @@ class Account:
                 verification.Witness(invocation_script, verification_script)
             )
 
-    def sign(self, data: bytes, password: str) -> bytes:
+    def sign(self, data: bytes) -> bytes:
         """
         Sign arbitrary data using the SECP256R1 curve.
 
         Args:
             data: data to be signed.
-            password: the password to decrypt the private key.
 
         Returns:
             signature of the signed data.
         """
         if self.is_watchonly:
             raise ValueError("Cannot sign transaction using a watch only account")
-        # mypy can't infer that the is_watchonly check ensures encrypted_key has a value
-        private_key = self.private_key_from_nep2(self.encrypted_key.decode("utf-8"), password, _scrypt_parameters=self.scrypt_parameters)  # type: ignore
-        return cryptography.sign(data, private_key)
+        return cryptography.sign(data, self.private_key)
 
     @classmethod
     def create_new(
-        cls, password: str, scrypt_parameters: Optional[scrypt.ScryptParameters] = None
+        cls, scrypt_parameters: Optional[scrypt.ScryptParameters] = None
     ) -> Account:
         """
         Instantiate and returns a new account encrypted using password.
 
         Args:
-            password: the password to decrypt the nep2 key.
             scrypt_parameters: supply custom Scrypt parameters.
 
         Returns:
             The newly created account.
         """
-        return cls(
-            password=password, watch_only=False, scrypt_parameters=scrypt_parameters
-        )
+        return cls(watch_only=False, scrypt_parameters=scrypt_parameters)
 
     @classmethod
     def from_encrypted_key(
@@ -445,7 +425,6 @@ class Account:
             The newly created account.
         """
         return cls(
-            password=password,
             private_key=cls.private_key_from_nep2(
                 encrypted_key, password, scrypt_parameters
             ),
@@ -456,7 +435,6 @@ class Account:
     def from_private_key(
         cls,
         private_key: bytes,
-        password: str,
         scrypt_parameters: Optional[scrypt.ScryptParameters] = None,
     ) -> Account:
         """
@@ -464,7 +442,6 @@ class Account:
 
         Args:
             private_key: the private key that will be used to create an encrypted key.
-            password: the password to encrypt a randomly generated private key.
             scrypt_parameters: optional custom parameters to be used in the Scrypt algorithm. Default settings conform
             to the NEP-2 standard.
 
@@ -472,7 +449,6 @@ class Account:
             the newly created account.
         """
         return cls(
-            password=password,
             private_key=private_key,
             scrypt_parameters=scrypt_parameters,
         )
@@ -481,7 +457,6 @@ class Account:
     def from_wif(
         cls,
         wif: str,
-        password: str,
         _scrypt_parameters: Optional[scrypt.ScryptParameters] = None,
     ) -> Account:
         """
@@ -489,14 +464,12 @@ class Account:
 
         Args:
             wif: the wif that will be decrypted to get a private key and generate an encrypted key.
-            password: the password to encrypt the private key with.
             _scrypt_parameters: the Scrypt parameters to use to encode the private key. Default conforms to NEP-2.
 
         Returns:
             the newly created account.
         """
         return cls(
-            password=password,
             private_key=cls.private_key_from_wif(wif),
             scrypt_parameters=_scrypt_parameters,
         )
@@ -513,7 +486,6 @@ class Account:
             the account that will be monitored.
         """
         return cls(
-            password="",
             watch_only=True,
             address=utils.script_hash_to_address(script_hash),
         )
@@ -529,15 +501,22 @@ class Account:
         Returns:
             the account that will be monitored.
         """
-        return cls(password="", watch_only=True, address=address)
+        return cls(watch_only=True, address=address)
 
-    def to_json(self) -> dict:
+    def to_json(self, password: str, scrypt_parameters: Optional[scrypt.ScryptParameters] = None) -> dict:
+        """
+        Encode account into NEP-6 JSON format
+
+        Args:
+             password: passphrase to use to encode the private key using NEP-2.
+             scrypt_parameters: the Scrypt parameters to use to encode the private key. Default conforms to NEP-2.
+        """
         return {
             "address": self.address,
             "label": self.label,
             "lock": self.lock,
-            "key": self.encrypted_key.decode("utf-8")
-            if self.encrypted_key is not None
+            "key": self.private_key_to_nep2(self.private_key, password, scrypt_parameters)
+            if self.private_key is not None
             else None,
             "contract": self.contract.to_json() if self.contract is not None else None,
             "extra": self.extra if len(self.extra) > 0 else None,
@@ -570,7 +549,6 @@ class Account:
             )
 
         return cls(
-            password=password,
             private_key=private_key,
             address=json["address"],
             label=json["label"],

--- a/neo3/wallet/account.py
+++ b/neo3/wallet/account.py
@@ -171,8 +171,7 @@ class Account:
         scrypt_parameters: Optional[scrypt.ScryptParameters] = None,
     ):
         """
-        Instantiate an account. This constructor should only be called directly when it's desired to create a new
-        account with a randomly generated private key, otherwise use the alternative constructors.
+        Do not call directly. Use the classmethods for creating an account.
         """
         public_key: Optional[cryptography.ECPoint] = None
         contract_script: Optional[bytes] = None

--- a/neo3/wallet/account.py
+++ b/neo3/wallet/account.py
@@ -386,7 +386,7 @@ class Account:
         if self.is_watchonly:
             raise ValueError("Cannot sign transaction using a watch only account")
         # mypy can't figure out that is_watchonly checks if private_key is None
-        return cryptography.sign(data, self.private_key) # type: ignore
+        return cryptography.sign(data, self.private_key)  # type: ignore
 
     @classmethod
     def create_new(

--- a/neo3/wallet/wallet.py
+++ b/neo3/wallet/wallet.py
@@ -268,7 +268,7 @@ class Wallet:
         Convert object into JSON representation.
 
         Args:
-            password: the passphrase to use to encrypt the private key.
+            password: the passphrase to use to encrypt the private key of the accounts.
         """
         return {
             "name": self.name,

--- a/neo3/wallet/wallet.py
+++ b/neo3/wallet/wallet.py
@@ -13,7 +13,7 @@ from neo3.wallet import account
 from neo3.wallet import scrypt_parameters as scrypt
 
 
-class Wallet(interfaces.IJson):
+class Wallet:
     """
     Base container.
     """
@@ -84,18 +84,16 @@ class Wallet(interfaces.IJson):
         self.extra = extra if extra else {}
 
     def account_new(
-        self, password: str, label: Optional[str] = None, is_default=False
+        self, label: Optional[str] = None, is_default=False
     ) -> account.Account:
         """
         Create a new account and adds it in the wallet.
 
         Args:
-            password: the password to encrypt the account.
             label: optional label to identify the account.
             is_default: set the created account as the default.
         """
         account_ = account.Account(
-            password=password,
             watch_only=False,
             label=label,
             scrypt_parameters=self.scrypt,
@@ -167,7 +165,7 @@ class Wallet(interfaces.IJson):
             for account_ in self.accounts:
                 if not account_.is_watchonly and account_.public_key in public_keys:
                     # copy key information of the first matching account
-                    acc.encrypted_key = account_.encrypted_key
+                    acc.private_key = account_.private_key
                     acc.public_key = account_.public_key
                     acc.scrypt_parameters = account_.scrypt_parameters
                     break
@@ -180,7 +178,7 @@ class Wallet(interfaces.IJson):
                         account_.contract.script
                     )
                     if acc.public_key in public_keys:
-                        account_.encrypted_key = acc.encrypted_key
+                        account_.private_key = acc.private_key
                         account_.public_key = acc.public_key
                         acc.scrypt_parameters = account_.scrypt_parameters
                         break
@@ -256,35 +254,44 @@ class Wallet(interfaces.IJson):
         # returns the account with given label. None if the account is not found
         return next((acc for acc in self.accounts if acc.label == label), None)
 
-    def save(self):
+    def save(self, password: str) -> None:
         """
         Save the wallet.
-
-        This is called automatically when using the context manager.
 
         See Also:
             [DiskWallet](#neo3.wallet.wallet.DiskWallet)
         """
         pass
 
-    def to_json(self) -> dict:
+    def to_json(self, password: str) -> dict:
         """
         Convert object into JSON representation.
+
+        Args:
+            password: the passphrase to use to encrypt the private key.
         """
         return {
             "name": self.name,
             "version": self.version,
             "scrypt": self.scrypt.to_json(),
-            "accounts": [self._account_to_json(acc) for acc in self.accounts],
+            "accounts": [
+                self._account_to_json(acc, password, self.scrypt)
+                for acc in self.accounts
+            ],
             "extra": self.extra if len(self.extra) > 0 else None,
         }
 
-    def _account_to_json(self, acc: account.Account) -> dict:
+    def _account_to_json(
+        self,
+        acc: account.Account,
+        password: str,
+        scrypt_params: Optional[scrypt.ScryptParameters] = None,
+    ) -> dict:
         is_default = (
             self._default_account is not None
             and self._default_account.address == acc.address
         )
-        json_account = acc.to_json()
+        json_account = acc.to_json(password, scrypt_params)
         json_account["isDefault"] = is_default
         return json_account
 
@@ -355,12 +362,6 @@ class Wallet(interfaces.IJson):
         with open(path, "r") as f:
             return cls.from_json(json.load(f), passwords)
 
-    def __enter__(self) -> Wallet:
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
-        self.save()
-
 
 class DiskWallet(Wallet):
     """
@@ -410,12 +411,12 @@ class DiskWallet(Wallet):
             extra=extra,
         )
 
-    def save(self) -> None:
+    def save(self, password: str) -> None:
         """
         Persist the wallet to disk.
         """
         with open(self.path, "w") as json_file:
-            json.dump(self.to_json(), json_file)
+            json.dump(self.to_json(password), json_file)
 
     @classmethod
     def default(


### PR DESCRIPTION
We move away from always requiring a password and storing an encrypted private key internally to simply storing the private key. It complicated a lot with arguably minor benefits

Breaking changes:
## signing functions
- renamed `sign_insecure_with_account` -> `sign_with_account`
   - also removed `password` argument
- renamed `sign_insecure_with_multisig_account` -> `sign_with_multisig_account`
   - also removed `password` argument
- removed `sign_secure_with_account`

## Account
- removed `password` argument from `sign`, `sign_tx`, `sign_multisig_tx`, `create_new`, `from_encrypted_key`, `from_private_key`, `from_wif`
- added `password` argument to `to_json` & `from_json`

## Wallet
- removed `password` argument from `account_new`
- added `password` argument to `save`, `to_json`
- removed context manager
