### PR TITLE
setup: resolve various build warnings

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,13 +1,9 @@
-include CHANGELOG.rst
 include LICENSE.md
 include Makefile
 include README.rst
-include setup.cfg
 graft examples/*
 graft docs/*
-include docs/make.bat
-include docs/Makefile
-recursive-exclude docs/build/*
+recursive-exclude docs/build *
 include neo3/py.typed
 graft neo3/*
 graft tests/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ name = "neo-mamba"
 description = "Python SDK for the NEO 3 blockchain"
 readme = "README.rst"
 requires-python = ">= 3.11.0,<= 3.13"
-license = { file = "LICENSE.md" }
+license = 'MIT'
+license-files = ["LICENSE.md"]
 keywords = ["NEO", "NEO3", "blockchain", "SDK"]
 authors = [
     { name = "Erik van den Brink", email = "erik@coz.io" },


### PR DESCRIPTION
Similar to https://github.com/CityOfZion/neo3-boa/pull/1281 we preemptively resolve the pyproject.toml warnings for `build`. While doing so I also noticed some outdated lines in `MANIFEST.in`