### PR TITLE
sctesting: fix unclosed file ResourceWarning's using `NeoGoNode`

### DIFF
--- a/neo3/sctesting/node.py
+++ b/neo3/sctesting/node.py
@@ -93,7 +93,7 @@ class NeoGoNode:
 
         def process_stdout(process):
             capture = True
-            for output in iter(process.stdout.readline, b""):
+            for output in iter(process.stdout.readline, ""):
                 if "RPC server already started" in output:
                     self._ready = True
                     # WARNING: do not terminate this loop. stdout must be read as long as the process lives otherwise
@@ -126,6 +126,10 @@ class NeoGoNode:
 
         if self._thread is not None and self._thread.is_alive():
             self._terminate = True
+            self._thread.join()
+
+        if self._process is not None and self._process.stdout is not None:
+            self._process.stdout.close()
         log.debug("stopped")
 
     def reset(self):


### PR DESCRIPTION
e2e tests could give the following warning
```
<sys>:0: ResourceWarning: unclosed file <_io.TextIOWrapper name=46 encoding='UTF-8'>
```
This is because `kill()` and `wait()` on the `Popen` object does not close the pipes. And since we open the process in text mode the sentinel for `readline` was wrong as well.