### PR TITLE
compiler: validate manifest permissions vs external contract calls

### DIFF
--- a/neo3/compiler/__init__.py
+++ b/neo3/compiler/__init__.py
@@ -9,6 +9,7 @@ import ast
 import hashlib
 import json
 import os
+import warnings
 from typing import Optional
 
 from neo3.contracts.abi import (
@@ -20,6 +21,7 @@ from neo3.contracts.abi import (
 )
 from neo3.contracts.manifest import ContractManifest
 from neo3.contracts.nef import NEF
+from neo3.core.types import UInt160
 
 from .types import (
     Type,
@@ -32,6 +34,7 @@ from .types import (
     UInt160Type,
     UInt256Type,
     ECPointType,
+    CompilerWarning,
     TypecheckError,
     INT,
     BOOL,
@@ -55,6 +58,7 @@ from .hir import (
     _PublicMethodInfo,
     _EventInfo,
     _collect_write_ops,
+    _collect_contract_calls,
 )
 from .hir_builder import (
     HIRBuilder,
@@ -78,6 +82,35 @@ from .linearizer import (
     _emit_static_literal,
     _emit_to_bytes_helper,
 )
+
+# Strip internal compiler file/line info from CompilerWarning messages so the
+# output is useful to contract authors rather than compiler developers.
+_orig_formatwarning = warnings.formatwarning
+
+
+def _formatwarning(message, category, filename, lineno, line=None):
+    if issubclass(category, CompilerWarning):
+        return f"{category.__name__}: {message}\n"
+    return _orig_formatwarning(message, category, filename, lineno, line)
+
+
+warnings.formatwarning = _formatwarning
+
+
+def _loc(
+    filename: Optional[str], lineno: Optional[int], col_offset: Optional[int]
+) -> str:
+    """Return a 'file, line N, col M: ' prefix for warning messages, or '' if no info."""
+    parts: list[str] = []
+    if filename:
+        parts.append(filename)
+    if lineno is not None:
+        loc = f"line {lineno}"
+        if col_offset is not None:
+            loc += f", col {col_offset + 1}"
+        parts.append(loc)
+    return (", ".join(parts) + ": ") if parts else ""
+
 
 # ---------------------------------------------------------------------------
 # Pre-built class info for built-in NeoVM-mapped types
@@ -718,6 +751,85 @@ def _compile_full(
                     ),
                 )
 
+    # Permission validation: if the manifest overrides permissions with a non-trivial
+    # list, verify that every static external contract call is covered.
+    if manifest_override and "permissions" in manifest_override:
+        perms: list[dict] = manifest_override["permissions"]
+        has_full_wildcard = any(
+            p.get("contract") == "*" and p.get("methods") == "*" for p in perms
+        )
+        if not has_full_wildcard:
+            has_group = any(
+                p.get("contract", "").startswith(("02", "03")) for p in perms
+            )
+            if has_group:
+                for p in perms:
+                    if p.get("contract", "").startswith(("02", "03")):
+                        prefix = _loc(
+                            p.get("_filename"), p.get("_lineno"), p.get("_col_offset")
+                        )
+                        warnings.warn(
+                            f"{prefix}ContractManifest contains a group-based permission; "
+                            "external call permissions cannot be statically validated.",
+                            CompilerWarning,
+                            stacklevel=2,
+                        )
+            _perm_fn_map: dict[str, HIRFunction] = {h.name: h for h, _ in pairs}
+            all_ext_calls: list[tuple[bytes, str]] = []
+            all_dyn_locs: list[tuple[Optional[int], Optional[int], Optional[str]]] = []
+            for hir_fn, _ in pairs:
+                ext_calls, dyn_locs = _collect_contract_calls(hir_fn.body, _perm_fn_map)
+                all_ext_calls.extend(ext_calls)
+                all_dyn_locs.extend(dyn_locs)
+            seen_dyn: set[tuple] = set()
+            for dyn_lineno, dyn_col, dyn_file in all_dyn_locs:
+                key = (dyn_lineno, dyn_col, dyn_file)
+                if key in seen_dyn:
+                    continue
+                seen_dyn.add(key)
+                prefix = _loc(dyn_file, dyn_lineno, dyn_col)
+                warnings.warn(
+                    f"{prefix}call_contract() (dynamic dispatch) cannot be "
+                    "permission-validated at compile time.",
+                    CompilerWarning,
+                    stacklevel=2,
+                )
+            if not has_group:
+                permitted: list[tuple[Optional[bytes], Optional[list[str]]]] = []
+                for p in perms:
+                    c = p.get("contract", "*")
+                    m = p.get("methods", "*")
+                    p_hash = None if c == "*" else UInt160.from_string(c).to_array()
+                    p_methods = (
+                        None if m == "*" else (m if isinstance(m, list) else [m])
+                    )
+                    permitted.append((p_hash, p_methods))
+                missing: list[tuple[str, str]] = []
+                seen_calls: set[tuple[bytes, str]] = set()
+                for call_hash, call_method in all_ext_calls:
+                    key = (call_hash, call_method)
+                    if key in seen_calls:
+                        continue
+                    seen_calls.add(key)
+                    covered = any(
+                        (p_hash is None or p_hash == call_hash)
+                        and (p_methods is None or call_method in p_methods)
+                        for p_hash, p_methods in permitted
+                    )
+                    if not covered:
+                        hash_str = "0x" + call_hash[::-1].hex()
+                        missing.append((hash_str, call_method))
+                if missing:
+                    lines = [f"  {h}.{m}" for h, m in missing]
+                    raise TypecheckError(
+                        "ContractManifest permissions do not cover the following "
+                        "external contract calls:\n"
+                        + "\n".join(lines)
+                        + "\nAdd the missing permissions or use "
+                        "Permission(contract='*', methods='*').",
+                        filename=filename,
+                    )
+
     # Linearize all functions into a shared emitter
     shared_em = Emitter()
     call_fixups: list[tuple[int, int, str]] = []
@@ -863,6 +975,11 @@ def compile_to_nef(source: str, output_path: str) -> None:
 
     manifest_json = manifest.to_json()
     if manifest_override:
+        if "permissions" in manifest_override:
+            manifest_override["permissions"] = [
+                {k: v for k, v in p.items() if not k.startswith("_")}
+                for p in manifest_override["permissions"]
+            ]
         manifest_json.update(manifest_override)
 
     try:

--- a/neo3/compiler/hir.py
+++ b/neo3/compiler/hir.py
@@ -313,6 +313,9 @@ class DynamicContractCall:
     call_flags: "Expr"  # int (Integer)
     type: Type = dataclasses.field(default_factory=lambda: ANY)
     is_stmt: bool = False
+    lineno: Optional[int] = None
+    col_offset: Optional[int] = None
+    filename: Optional[str] = None
 
 
 @dataclasses.dataclass
@@ -1189,3 +1192,74 @@ def _collect_write_ops(
     found: list[tuple[str, Optional[int], Optional[int], Optional[str]]] = []
     _walk_hir_node(stmts, hir_fn_map, visited, found)
     return found
+
+
+def _walk_contract_calls(
+    node: object,
+    hir_fn_map: dict,
+    visited: set[str],
+    calls: "list[tuple[bytes, str]]",
+    dyn_locs: "list[tuple[Optional[int], Optional[int], Optional[str]]]",
+) -> None:
+    """Recursively walk HIR nodes, collecting ContractCall and DynamicContractCall info."""
+    if node is None:
+        return
+    if isinstance(node, list):
+        for item in node:
+            _walk_contract_calls(item, hir_fn_map, visited, calls, dyn_locs)
+        return
+    if isinstance(node, ContractCall):
+        calls.append((node.contract_hash, node.method))
+        for arg in node.args:
+            _walk_contract_calls(arg, hir_fn_map, visited, calls, dyn_locs)
+        return
+    if isinstance(node, DynamicContractCall):
+        dyn_locs.append((node.lineno, node.col_offset, node.filename))
+        return
+    if isinstance(node, (Call, CallStmt)):
+        fn_name = node.name
+        if fn_name not in visited and fn_name in hir_fn_map:
+            visited.add(fn_name)
+            _walk_contract_calls(
+                hir_fn_map[fn_name].body, hir_fn_map, visited, calls, dyn_locs
+            )
+        for arg in node.args:
+            _walk_contract_calls(arg, hir_fn_map, visited, calls, dyn_locs)
+        return
+    if isinstance(node, (MethodCall, MethodCallStmt)):
+        fn_name = node.compiled_name
+        if fn_name not in visited and fn_name in hir_fn_map:
+            visited.add(fn_name)
+            _walk_contract_calls(
+                hir_fn_map[fn_name].body, hir_fn_map, visited, calls, dyn_locs
+            )
+        _walk_contract_calls(node.obj, hir_fn_map, visited, calls, dyn_locs)
+        for arg in node.args:
+            _walk_contract_calls(arg, hir_fn_map, visited, calls, dyn_locs)
+        return
+    if isinstance(node, NewInstance):
+        init_name = f"{node.class_name}___init__"
+        if init_name not in visited and init_name in hir_fn_map:
+            visited.add(init_name)
+            _walk_contract_calls(
+                hir_fn_map[init_name].body, hir_fn_map, visited, calls, dyn_locs
+            )
+        for arg in node.args:
+            _walk_contract_calls(arg, hir_fn_map, visited, calls, dyn_locs)
+        return
+    if dataclasses.is_dataclass(node) and not isinstance(node, type):
+        for f in dataclasses.fields(node):
+            val = getattr(node, f.name)
+            if val is None or isinstance(val, (int, float, str, bool, bytes)):
+                continue
+            _walk_contract_calls(val, hir_fn_map, visited, calls, dyn_locs)
+
+
+def _collect_contract_calls(
+    stmts: list, hir_fn_map: dict[str, "HIRFunction"]
+) -> "tuple[list[tuple[bytes, str]], list[tuple[Optional[int], Optional[int], Optional[str]]]]":
+    """Walk HIR and return ([(contract_hash_le, method), ...], [(lineno, col_offset, filename), ...])."""
+    calls: list[tuple[bytes, str]] = []
+    dyn_locs: list[tuple[Optional[int], Optional[int], Optional[str]]] = []
+    _walk_contract_calls(stmts, hir_fn_map, set(), calls, dyn_locs)
+    return calls, dyn_locs

--- a/neo3/compiler/hir_builder.py
+++ b/neo3/compiler/hir_builder.py
@@ -899,10 +899,15 @@ class HIRBuilder:
             case ast.Expr(
                 value=ast.Call(
                     func=ast.Name(id="call_contract"), args=cc_args, keywords=[]
-                )
+                ) as cc_node
             ):
                 # call_contract() used as a statement — result is discarded (DROP in CFGBuilder).
-                return self._build_call_contract(cc_args, is_stmt=True)
+                return self._build_call_contract(
+                    cc_args,
+                    is_stmt=True,
+                    lineno=cc_node.lineno,
+                    col_offset=cc_node.col_offset,
+                )
 
             case ast.Expr(
                 value=ast.Call(func=ast.Name(id=name), args=call_args, keywords=[])
@@ -1351,7 +1356,11 @@ class HIRBuilder:
         )
 
     def _build_call_contract(
-        self, pos_args: list[ast.expr], is_stmt: bool = False
+        self,
+        pos_args: list[ast.expr],
+        is_stmt: bool = False,
+        lineno: Optional[int] = None,
+        col_offset: Optional[int] = None,
     ) -> "DynamicContractCall":
         """Validate and build a DynamicContractCall node for the call_contract() intrinsic."""
         n = len(pos_args)
@@ -1380,7 +1389,15 @@ class HIRBuilder:
         else:
             cf = IntLiteral(15)  # CallFlags.ALL
         return DynamicContractCall(
-            script_hash=sh, method=m, args=a, call_flags=cf, type=ANY, is_stmt=is_stmt
+            script_hash=sh,
+            method=m,
+            args=a,
+            call_flags=cf,
+            type=ANY,
+            is_stmt=is_stmt,
+            lineno=lineno,
+            col_offset=col_offset,
+            filename=self._filename,
         )
 
     def _extract_none_check(self, test: ast.expr) -> Optional[tuple[str, bool]]:
@@ -3285,8 +3302,12 @@ class HIRBuilder:
                         f"ECPoint() requires exactly 33 bytes (got {len(arg.value)})"
                     )
                 return TypeConvert(arg=arg, type=ECPOINT)
-            case ast.Call(func=ast.Name(id="call_contract"), args=cc_args, keywords=[]):
-                return self._build_call_contract(cc_args)
+            case ast.Call(
+                func=ast.Name(id="call_contract"), args=cc_args, keywords=[]
+            ) as cc_node:
+                return self._build_call_contract(
+                    cc_args, lineno=cc_node.lineno, col_offset=cc_node.col_offset
+                )
             case ast.Call(
                 func=ast.Attribute(value=recv_node, attr="next"),
                 args=[],
@@ -6134,7 +6155,38 @@ def _extract_permissions_list(
                 filename=filename,
             )
         perm: dict = {"contract": "*", "methods": "*"}
+        # Handle positional args: Permission(contract, methods) → mapped by position
+        param_names = ["contract", "methods"]
+        perm_pos_filled: set[str] = set()
+        for i, arg in enumerate(elt.args):
+            if i >= len(param_names):
+                raise TypecheckError(
+                    "ContractManifest 'permissions': Permission(...) takes at most 2 positional arguments",
+                    lineno=getattr(arg, "lineno", None),
+                    col_offset=getattr(arg, "col_offset", None),
+                    filename=filename,
+                )
+            pname = param_names[i]
+            val = _ast_literal_to_python(arg, f"permissions.{pname}", filename)
+            if pname == "contract":
+                if not isinstance(val, str):
+                    raise TypecheckError(
+                        "ContractManifest 'permissions.contract': must be a string",
+                        lineno=getattr(arg, "lineno", None),
+                        col_offset=getattr(arg, "col_offset", None),
+                        filename=filename,
+                    )
+                _validate_contract_descriptor(val, arg, filename)
+            perm[pname] = val
+            perm_pos_filled.add(pname)
         for kw in elt.keywords:
+            if kw.arg in perm_pos_filled:
+                raise TypecheckError(
+                    f"ContractManifest 'permissions': Permission(...) got multiple values for argument '{kw.arg}'",
+                    lineno=getattr(kw.value, "lineno", None),
+                    col_offset=getattr(kw.value, "col_offset", None),
+                    filename=filename,
+                )
             if kw.arg == "contract":
                 val = _ast_literal_to_python(kw.value, "permissions.contract", filename)
                 if not isinstance(val, str):
@@ -6157,6 +6209,9 @@ def _extract_permissions_list(
                     col_offset=getattr(kw.value, "col_offset", None),
                     filename=filename,
                 )
+        perm["_lineno"] = getattr(elt, "lineno", None)
+        perm["_col_offset"] = getattr(elt, "col_offset", None)
+        perm["_filename"] = filename
         result.append(perm)
     return result
 
@@ -6182,7 +6237,40 @@ def _extract_groups_list(
                 filename=filename,
             )
         group: dict = {}
+        # Handle positional args: Group(pubkey, signature) → mapped by position
+        group_param_names = ["pubkey", "signature"]
+        group_pos_filled: set[str] = set()
+        for i, arg in enumerate(elt.args):
+            if i >= len(group_param_names):
+                raise TypecheckError(
+                    "ContractManifest 'groups': Group(...) takes at most 2 positional arguments",
+                    lineno=getattr(arg, "lineno", None),
+                    col_offset=getattr(arg, "col_offset", None),
+                    filename=filename,
+                )
+            pname = group_param_names[i]
+            val = _ast_literal_to_python(arg, f"groups.{pname}", filename)
+            if not isinstance(val, str):
+                raise TypecheckError(
+                    f"ContractManifest 'groups.{pname}': must be a string",
+                    lineno=getattr(arg, "lineno", None),
+                    col_offset=getattr(arg, "col_offset", None),
+                    filename=filename,
+                )
+            if pname == "pubkey":
+                _validate_ecpoint_hex(val, arg, filename)
+            else:
+                _validate_group_signature(val, arg, filename)
+            group[pname] = val
+            group_pos_filled.add(pname)
         for kw in elt.keywords:
+            if kw.arg in group_pos_filled:
+                raise TypecheckError(
+                    f"ContractManifest 'groups': Group(...) got multiple values for argument '{kw.arg}'",
+                    lineno=getattr(kw.value, "lineno", None),
+                    col_offset=getattr(kw.value, "col_offset", None),
+                    filename=filename,
+                )
             if kw.arg in ("pubkey", "signature"):
                 val = _ast_literal_to_python(kw.value, f"groups.{kw.arg}", filename)
                 if not isinstance(val, str):
@@ -6221,12 +6309,67 @@ def _extract_manifest_call_kwargs(
     filename: Optional[str] = None,
 ) -> dict:
     result: dict = {}
+    # Handle positional args mapped to parameter names by position
+    _manifest_param_names = [
+        "name",
+        "groups",
+        "supported_standards",
+        "permissions",
+        "trusts",
+        "extra",
+    ]
+    for i, arg in enumerate(call.args):
+        if i >= len(_manifest_param_names):
+            raise TypecheckError(
+                "ContractManifest takes at most 6 positional arguments",
+                lineno=getattr(arg, "lineno", None),
+                col_offset=getattr(arg, "col_offset", None),
+                filename=filename,
+            )
+        # Reuse the keyword-argument handling by synthesising a keyword node
+        kw_arg = _manifest_param_names[i]
+        if kw_arg == "name":
+            val = _ast_literal_to_python(arg, "name", filename)
+            if not isinstance(val, str):
+                raise TypecheckError(
+                    "ContractManifest 'name': must be a string literal",
+                    lineno=getattr(arg, "lineno", None),
+                    col_offset=getattr(arg, "col_offset", None),
+                    filename=filename,
+                )
+            result["name"] = val
+        elif kw_arg == "groups":
+            result["groups"] = _extract_groups_list(arg, filename)
+        elif kw_arg == "supported_standards":
+            val = _ast_literal_to_python(arg, "supported_standards", filename)
+            if not isinstance(val, list):
+                raise TypecheckError(
+                    "ContractManifest 'supported_standards': must be a list of strings",
+                    lineno=getattr(arg, "lineno", None),
+                    col_offset=getattr(arg, "col_offset", None),
+                    filename=filename,
+                )
+            result["supportedstandards"] = val
+        elif kw_arg == "permissions":
+            result["permissions"] = _extract_permissions_list(arg, filename)
+        elif kw_arg == "trusts":
+            result["trusts"] = _ast_literal_to_python(arg, "trusts", filename)
+        elif kw_arg == "extra":
+            result["extra"] = _ast_literal_to_python(arg, "extra", filename)
+    _manifest_pos_filled = set(_manifest_param_names[: len(call.args)])
     for kw in call.keywords:
         if kw.arg is None:
             raise TypecheckError(
                 "ContractManifest does not support **kwargs unpacking",
                 lineno=getattr(call, "lineno", None),
                 col_offset=getattr(call, "col_offset", None),
+                filename=filename,
+            )
+        if kw.arg in _manifest_pos_filled:
+            raise TypecheckError(
+                f"ContractManifest got multiple values for argument '{kw.arg}'",
+                lineno=getattr(kw.value, "lineno", None),
+                col_offset=getattr(kw.value, "col_offset", None),
                 filename=filename,
             )
         if kw.arg == "name":

--- a/neo3/compiler/types.py
+++ b/neo3/compiler/types.py
@@ -182,6 +182,10 @@ LIST_STR = ListType(STR)
 _BYTESLIKE = (BytesType, BytearrayType, StrType, UInt160Type, UInt256Type, ECPointType)
 
 
+class CompilerWarning(UserWarning):
+    pass
+
+
 class TypecheckError(Exception):
     def __init__(
         self,

--- a/tests/compiler/tests/test_nef_manifest.py
+++ b/tests/compiler/tests/test_nef_manifest.py
@@ -6,7 +6,7 @@ import os
 import tempfile
 import unittest
 
-from neo3.compiler import compile_to_nef
+from neo3.compiler import compile_to_nef, CompilerWarning
 
 # Minimal contract with one @public method and one @public(safe=True) method.
 _SRC = """
@@ -382,6 +382,103 @@ def x() -> int:
             _write_contract(src)
         self.assertIn("unknown_field", str(ctx.exception))
 
+    def test_permission_positional_args(self):
+        """Permission("*", ["transfer"]) with positional args is parsed correctly."""
+        src = """
+from neo3.sc.compiletime import public, ContractManifest, Permission
+ContractManifest(permissions=[Permission("*", ["transfer"])])
+@public
+def x() -> int:
+    return 1
+"""
+        manifest = self._compile(src)
+        perms = manifest["permissions"]
+        self.assertEqual(len(perms), 1)
+        self.assertEqual(perms[0]["contract"], "*")
+        self.assertEqual(perms[0]["methods"], ["transfer"])
+
+    def test_permission_duplicate_arg_raises(self):
+        """Permission("*", contract="0x...") — same param via positional and keyword → error."""
+        from neo3.compiler import TypecheckError
+
+        src = """
+from neo3.sc.compiletime import public, ContractManifest, Permission
+ContractManifest(permissions=[Permission("*", contract="*")])
+@public
+def x() -> int:
+    return 1
+"""
+        with self.assertRaises(TypecheckError) as ctx:
+            _write_contract(src)
+        self.assertIn("multiple values", str(ctx.exception))
+
+    def test_group_positional_args(self):
+        """Group(pubkey, signature) with positional args is parsed correctly."""
+        src = """
+from neo3.sc.compiletime import public, ContractManifest, Group
+ContractManifest(
+    groups=[Group(
+        "02c0b60c995bc092e866f15a37c176bb59b7ebacf069ba94c38654a316479b7af4",
+        "QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQQ==",
+    )]
+)
+@public
+def x() -> int:
+    return 1
+"""
+        manifest = self._compile(src)
+        groups = manifest["groups"]
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(
+            groups[0]["pubkey"],
+            "02c0b60c995bc092e866f15a37c176bb59b7ebacf069ba94c38654a316479b7af4",
+        )
+
+    def test_group_duplicate_arg_raises(self):
+        """Group(pubkey_val, pubkey=...) — same param via positional and keyword → error."""
+        from neo3.compiler import TypecheckError
+
+        src = """
+from neo3.sc.compiletime import public, ContractManifest, Group
+ContractManifest(groups=[Group(
+    "02c0b60c995bc092e866f15a37c176bb59b7ebacf069ba94c38654a316479b7af4",
+    pubkey="02c0b60c995bc092e866f15a37c176bb59b7ebacf069ba94c38654a316479b7af4",
+)])
+@public
+def x() -> int:
+    return 1
+"""
+        with self.assertRaises(TypecheckError) as ctx:
+            _write_contract(src)
+        self.assertIn("multiple values", str(ctx.exception))
+
+    def test_contract_manifest_positional_name(self):
+        """ContractManifest("MyToken") with positional name arg is parsed correctly."""
+        src = """
+from neo3.sc.compiletime import public, ContractManifest
+ContractManifest("MyToken")
+@public
+def x() -> int:
+    return 1
+"""
+        manifest = self._compile(src)
+        self.assertEqual(manifest["name"], "MyToken")
+
+    def test_contract_manifest_duplicate_arg_raises(self):
+        """ContractManifest("Foo", name="Bar") — same param positional and keyword → error."""
+        from neo3.compiler import TypecheckError
+
+        src = """
+from neo3.sc.compiletime import public, ContractManifest
+ContractManifest("Foo", name="Bar")
+@public
+def x() -> int:
+    return 1
+"""
+        with self.assertRaises(TypecheckError) as ctx:
+            _write_contract(src)
+        self.assertIn("multiple values", str(ctx.exception))
+
     def test_permission_invalid_contract_raises(self):
         from neo3.compiler import TypecheckError
 
@@ -423,3 +520,237 @@ def x() -> int:
         with self.assertRaises(TypecheckError) as ctx:
             _write_contract(src)
         self.assertIn("signature", str(ctx.exception))
+
+
+# Reusable @contract class definition for permission validation tests.
+_STDLIB_CONTRACT_DEF = """\
+from typing import Any
+from neo3.sc.compiletime import contract
+from neo3.sc.types import UInt160
+
+@contract('0xacce6fd80d44e1796aa0c2c625e9e4e0ce39efc0')
+class StdLib:
+    @staticmethod
+    def serialize(item: Any) -> bytes:
+        pass
+
+    @staticmethod
+    def deserialize(data: bytes) -> Any:
+        pass
+
+"""
+
+_STDLIB_HASH = "0xacce6fd80d44e1796aa0c2c625e9e4e0ce39efc0"
+_OTHER_HASH = "0xd2a4cff31913016155e38e474a2c06d08be276cf"
+
+
+class TestPermissionValidation(unittest.TestCase):
+    """Compile-time validation that declared permissions cover all external calls."""
+
+    def _compile_ok(self, src: str) -> dict:
+        _, manifest = _write_contract(src)
+        return manifest
+
+    def _compile_err(self, src: str) -> str:
+        from neo3.compiler import TypecheckError
+
+        with self.assertRaises(TypecheckError) as ctx:
+            _write_contract(src)
+        return str(ctx.exception)
+
+    def test_no_override_no_error(self):
+        """No ContractManifest → default wildcard permissions, no validation needed."""
+        src = (
+            _STDLIB_CONTRACT_DEF + "from neo3.sc.compiletime import public\n"
+            "@public\n"
+            "def f(x: int) -> bytes:\n"
+            "    return StdLib.serialize(x)\n"
+        )
+        self._compile_ok(src)
+
+    def test_full_wildcard_ok(self):
+        """Permission(contract='*', methods='*') covers any external call."""
+        src = (
+            _STDLIB_CONTRACT_DEF
+            + "from neo3.sc.compiletime import public, ContractManifest, Permission\n"
+            "ContractManifest(permissions=[Permission(contract='*', methods='*')])\n"
+            "@public\n"
+            "def f(x: int) -> bytes:\n"
+            "    return StdLib.serialize(x)\n"
+        )
+        self._compile_ok(src)
+
+    def test_contract_wildcard_ok(self):
+        """contract='*' with a specific method list covers any contract for those methods."""
+        src = (
+            _STDLIB_CONTRACT_DEF
+            + "from neo3.sc.compiletime import public, ContractManifest, Permission\n"
+            f"ContractManifest(permissions=[Permission(contract='*', methods=['serialize'])])\n"
+            "@public\n"
+            "def f(x: int) -> bytes:\n"
+            "    return StdLib.serialize(x)\n"
+        )
+        self._compile_ok(src)
+
+    def test_methods_wildcard_ok(self):
+        """methods='*' covers all methods on a specific contract."""
+        src = (
+            _STDLIB_CONTRACT_DEF
+            + "from neo3.sc.compiletime import public, ContractManifest, Permission\n"
+            f"ContractManifest(permissions=[Permission(contract='{_STDLIB_HASH}', methods='*')])\n"
+            "@public\n"
+            "def f(x: int) -> bytes:\n"
+            "    return StdLib.serialize(x)\n"
+        )
+        self._compile_ok(src)
+
+    def test_exact_match_ok(self):
+        """Exact (contract, method) permission covers the call."""
+        src = (
+            _STDLIB_CONTRACT_DEF
+            + "from neo3.sc.compiletime import public, ContractManifest, Permission\n"
+            f"ContractManifest(permissions=[Permission(contract='{_STDLIB_HASH}', methods=['serialize'])])\n"
+            "@public\n"
+            "def f(x: int) -> bytes:\n"
+            "    return StdLib.serialize(x)\n"
+        )
+        self._compile_ok(src)
+
+    def test_missing_method_raises(self):
+        """Permission lists only 'serialize' but contract also calls 'deserialize' → error."""
+        src = (
+            _STDLIB_CONTRACT_DEF + "from typing import Any\n"
+            "from neo3.sc.compiletime import public, ContractManifest, Permission\n"
+            f"ContractManifest(permissions=[Permission(contract='{_STDLIB_HASH}', methods=['serialize'])])\n"
+            "@public\n"
+            "def f(x: int) -> Any:\n"
+            "    StdLib.serialize(x)\n"
+            "    return StdLib.deserialize(b'data')\n"
+        )
+        msg = self._compile_err(src)
+        self.assertIn("deserialize", msg)
+        self.assertIn(_STDLIB_HASH, msg)
+
+    def test_missing_contract_raises(self):
+        """Permission covers a different contract hash → error for StdLib calls."""
+        src = (
+            _STDLIB_CONTRACT_DEF
+            + "from neo3.sc.compiletime import public, ContractManifest, Permission\n"
+            f"ContractManifest(permissions=[Permission(contract='{_OTHER_HASH}', methods=['serialize'])])\n"
+            "@public\n"
+            "def f(x: int) -> bytes:\n"
+            "    return StdLib.serialize(x)\n"
+        )
+        msg = self._compile_err(src)
+        self.assertIn("serialize", msg)
+        self.assertIn(_STDLIB_HASH, msg)
+
+    def test_multiple_missing_reported_together(self):
+        """Both uncovered calls appear in the single error message."""
+        src = (
+            _STDLIB_CONTRACT_DEF + "from typing import Any\n"
+            "from neo3.sc.compiletime import public, ContractManifest, Permission\n"
+            f"ContractManifest(permissions=[Permission(contract='{_OTHER_HASH}', methods=['serialize'])])\n"
+            "@public\n"
+            "def f(x: int) -> Any:\n"
+            "    StdLib.serialize(x)\n"
+            "    return StdLib.deserialize(b'data')\n"
+        )
+        msg = self._compile_err(src)
+        self.assertIn("serialize", msg)
+        self.assertIn("deserialize", msg)
+
+    def test_dynamic_call_warns(self):
+        """call_contract() warns with location info pointing to the call site."""
+        src = (
+            "from typing import Any\n"
+            "from neo3.sc.compiletime import public, ContractManifest, Permission\n"
+            "from neo3.sc.types import UInt160, CallFlags\n"
+            "from neo3.sc.utils import call_contract\n"
+            f"ContractManifest(permissions=[Permission(contract='{_STDLIB_HASH}', methods=['transfer'])])\n"
+            "@public\n"
+            "def f(h: UInt160) -> Any:\n"
+            "    return call_contract(h, 'balanceOf', [], CallFlags.ALL)\n"
+        )
+        with self.assertWarns(CompilerWarning) as ctx:
+            _write_contract(src)
+        messages = [str(w.message) for w in ctx.warnings]
+        dyn_msgs = [m for m in messages if "dynamic" in m.lower()]
+        self.assertTrue(dyn_msgs, "expected a dynamic-call warning")
+        self.assertTrue(
+            all("line" in m for m in dyn_msgs), "expected line number in warning"
+        )
+
+    def test_dynamic_call_two_sites_two_warnings(self):
+        """Two distinct call_contract() call sites produce two separate warnings."""
+        src = (
+            "from typing import Any\n"
+            "from neo3.sc.compiletime import public, ContractManifest, Permission\n"
+            "from neo3.sc.types import UInt160, CallFlags\n"
+            "from neo3.sc.utils import call_contract\n"
+            f"ContractManifest(permissions=[Permission(contract='{_STDLIB_HASH}', methods=['itoa'])])\n"
+            "@public\n"
+            "def f(h: UInt160) -> Any:\n"
+            "    call_contract(h, 'itoa', [1, 10], CallFlags.ALL)\n"
+            "    return call_contract(h, 'atoi', ['1'], CallFlags.ALL)\n"
+        )
+        with self.assertWarns(CompilerWarning) as ctx:
+            _write_contract(src)
+        dyn_msgs = [
+            str(w.message) for w in ctx.warnings if "dynamic" in str(w.message).lower()
+        ]
+        self.assertEqual(len(dyn_msgs), 2, "expected one warning per call site")
+
+    def test_group_and_dynamic_both_warn(self):
+        """Group-based permission + call_contract() → both warnings are emitted with location."""
+        src = (
+            "from typing import Any\n"
+            "from neo3.sc.compiletime import public, ContractManifest, Permission\n"
+            "from neo3.sc.types import UInt160, CallFlags\n"
+            "from neo3.sc.utils import call_contract\n"
+            "ContractManifest(permissions=[\n"
+            f"    Permission('*', ['itoa']),\n"
+            "    Permission('02c0b60c995bc092e866f15a37c176bb59b7ebacf069ba94c38654a316479b7af4', 'atoi'),\n"
+            "])\n"
+            "@public\n"
+            "def f(h: UInt160) -> Any:\n"
+            "    return call_contract(h, 'itoa', [42, 10], CallFlags.ALL)\n"
+        )
+        with self.assertWarns(CompilerWarning) as ctx:
+            _write_contract(src)
+        messages = [str(w.message) for w in ctx.warnings]
+        group_msgs = [m for m in messages if "group" in m.lower()]
+        dyn_msgs = [m for m in messages if "dynamic" in m.lower()]
+        self.assertTrue(group_msgs, "expected a group-permission warning")
+        self.assertTrue(dyn_msgs, "expected a dynamic-call warning")
+        self.assertTrue(
+            all("line" in m for m in group_msgs),
+            "expected line number in group warning",
+        )
+        self.assertTrue(
+            all("line" in m for m in dyn_msgs),
+            "expected line number in dynamic warning",
+        )
+
+    def test_group_permission_warns(self):
+        """ECPoint-based permission warns with location pointing to the Permission entry."""
+        src = (
+            _STDLIB_CONTRACT_DEF
+            + "from neo3.sc.compiletime import public, ContractManifest, Permission\n"
+            "ContractManifest(permissions=["
+            "Permission(contract='02c0b60c995bc092e866f15a37c176bb59b7ebacf069ba94c38654a316479b7af4',"
+            " methods=['serialize'])"
+            "])\n"
+            "@public\n"
+            "def f(x: int) -> bytes:\n"
+            "    return StdLib.serialize(x)\n"
+        )
+        with self.assertWarns(CompilerWarning) as ctx:
+            _write_contract(src)
+        group_msgs = [
+            str(w.message) for w in ctx.warnings if "group" in str(w.message).lower()
+        ]
+        self.assertTrue(group_msgs, "expected a group-permission warning")
+        self.assertTrue(
+            all("line" in m for m in group_msgs), "expected line number in warning"
+        )


### PR DESCRIPTION
close #371

Notes:
- `call_contract()` calls are not validated. The arguments are Expr nodes (runtime expressions). If someone passes literal constants to `call_contract()` we could constant-fold them and validate but if they pass variables (e.g. a hash loaded from storage) we can't know the target at compile time. Easiest for now is just to not support it.
- a `Permission` using a `group` (=public key) also cannot be validated unless we would have access to the target contract manifest (so we can see if the public key exists). In theory possible by downloading the manifest from a chain, but goes a bit too far for this first iteration. Maybe in the future as enhancement.