### PR TITLE
testing: change aioresponses to aiointercept

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ maintainers = [
 dynamic = ["version"]
 dependencies = [
     "aiodns==3.6.1",
-    "aiohttp==3.13.2",
+    "aiohttp~=3.13",
     "base58==2.1.1",
     "bitarray==3.8.0",
     "jsonschema==4.25.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "aioresponses==0.7.6",
+    "aiointercept==0.1.5",
     "black==25.12.0",
     "build==0.10.0",
     "bump-my-version==0.12.0",

--- a/tests/api/test_noderpc.py
+++ b/tests/api/test_noderpc.py
@@ -13,7 +13,7 @@ JSON = Any
 
 class TestNeoRpcClient(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self) -> None:
-        
+
         self.helper = aiointercept()
         await self.helper.start()
         self.client = api.NeoRpcClient(self.helper.server_url)

--- a/tests/api/test_noderpc.py
+++ b/tests/api/test_noderpc.py
@@ -2,7 +2,7 @@ import unittest
 import base64
 from typing import Optional, Any
 import neo3crypto
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 from neo3 import api
 from neo3.network.payloads import transaction, block, verification
 from neo3.core import types, cryptography
@@ -13,13 +13,13 @@ JSON = Any
 
 class TestNeoRpcClient(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self) -> None:
-        self.client = api.NeoRpcClient("localhost")
-        # CAREFULL THIS PATCHES ALL aiohttp CALLS!
-        self.helper = aioresponses()
-        self.helper.start()
+        
+        self.helper = aiointercept()
+        await self.helper.start()
+        self.client = api.NeoRpcClient(self.helper.server_url)
 
     async def asyncTearDown(self) -> None:
-        self.helper.stop()
+        await self.helper.stop()
         await self.client.close()
 
     def mock_response(
@@ -33,9 +33,9 @@ class TestNeoRpcClient(unittest.IsolatedAsyncioTestCase):
 
         if payload is not None:
             json = {"jsonrpc": "2.0", "id": 1, "result": payload}
-            self.helper.post("localhost", payload=json)
+            self.helper.post(self.helper.server_url, payload=json)
         else:
-            self.helper.post("localhost", exception=exc)
+            self.helper.post(self.helper.server_url, exception=exc)
 
     async def test_calculate_network_fee(self):
         self.mock_response({"networkfee": "123"})
@@ -707,7 +707,7 @@ class TestNeoRpcClient(unittest.IsolatedAsyncioTestCase):
                     "data": "bogus_data",
                 },
             }
-            self.helper.post("localhost", payload=error_response)
+            self.helper.post(self.helper.server_url, payload=error_response)
             await self.client.validate_address("abc")
         self.assertIn("-2146233086", str(context.exception))
         self.assertIn("bogus_message", str(context.exception))

--- a/tests/api/test_wrappers.py
+++ b/tests/api/test_wrappers.py
@@ -1,6 +1,6 @@
 import unittest
 from typing import Optional, Any
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 from neo3.contracts.callflags import CallFlags
 from neo3.core import types
 from neo3.api.wrappers import _check_address_and_convert, ChainFacade, GenericContract
@@ -35,11 +35,11 @@ class WrapperUtilsTest(unittest.TestCase):
 class TestChainFacade(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self) -> None:
         # CAREFULL THIS PATCHES ALL aiohttp CALLS!
-        self.helper = aioresponses()
-        self.helper.start()
+        self.helper = aiointercept()
+        await self.helper.start()
 
     async def asyncTearDown(self) -> None:
-        self.helper.stop()
+        await self.helper.stop()
 
     def mock_response(
         self, payload: Optional[JSON] = None, exc: Optional[Exception] = None
@@ -52,9 +52,9 @@ class TestChainFacade(unittest.IsolatedAsyncioTestCase):
 
         if payload is not None:
             json = {"jsonrpc": "2.0", "id": 1, "result": payload}
-            self.helper.post("localhost", payload=json)
+            self.helper.post(self.helper.server_url, payload=json)
         else:
-            self.helper.post("localhost", exception=exc)
+            self.helper.post(self.helper.server_url, exception=exc)
 
     async def test_receipt_retry_delay_and_timeout(self):
         user_agent = "/Neo:3.0.3/"
@@ -83,25 +83,25 @@ class TestChainFacade(unittest.IsolatedAsyncioTestCase):
             },
         }
         self.mock_response(get_version_captured)
-        facade = ChainFacade("localhost")
+        facade = ChainFacade(self.helper.server_url)
         delay, timeout = await facade._get_receipt_time_values()
         self.assertEqual(3.0, delay)
         self.assertEqual(33.0, timeout)
 
         self.mock_response(get_version_captured)
-        facade = ChainFacade("localhost", receipt_timeout=1)
+        facade = ChainFacade(self.helper.server_url, receipt_timeout=1)
         delay, timeout = await facade._get_receipt_time_values()
         self.assertEqual(3.0, delay)
         self.assertEqual(1.0, timeout)
 
         self.mock_response(get_version_captured)
-        facade = ChainFacade("localhost", receipt_retry_delay=5)
+        facade = ChainFacade(self.helper.server_url, receipt_retry_delay=5)
         delay, timeout = await facade._get_receipt_time_values()
         self.assertEqual(5.0, delay)
         self.assertEqual(35.0, timeout)
 
         self.mock_response(get_version_captured)
-        facade = ChainFacade("localhost", receipt_retry_delay=5, receipt_timeout=1)
+        facade = ChainFacade(self.helper.server_url, receipt_retry_delay=5, receipt_timeout=1)
         delay, timeout = await facade._get_receipt_time_values()
         self.assertEqual(5.0, delay)
         self.assertEqual(1.0, timeout)

--- a/tests/api/test_wrappers.py
+++ b/tests/api/test_wrappers.py
@@ -101,7 +101,9 @@ class TestChainFacade(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(35.0, timeout)
 
         self.mock_response(get_version_captured)
-        facade = ChainFacade(self.helper.server_url, receipt_retry_delay=5, receipt_timeout=1)
+        facade = ChainFacade(
+            self.helper.server_url, receipt_retry_delay=5, receipt_timeout=1
+        )
         delay, timeout = await facade._get_receipt_time_values()
         self.assertEqual(5.0, delay)
         self.assertEqual(1.0, timeout)


### PR DESCRIPTION
Changed the test library from aioresponses to aiointercept. Aiointercept is a library that of wich I'm the maintainer. It has a API similar to aioresponses but it create a real server and does real request, against localhost. As this doesn't mock anything internal, it's not blocking requests against other servers
This solve: https://github.com/CityOfZion/neo-mamba/issues/382