### PR TITLE
ci, setup, sctesting: move node packaging into separate dependency

### DIFF
--- a/.github/workflows/release-node-to-pypi.yml
+++ b/.github/workflows/release-node-to-pypi.yml
@@ -1,0 +1,62 @@
+name: Release node-bin to PyPi
+
+on:
+  workflow_dispatch:
+    inputs:
+      pypi-target:
+        description: Deploy to PyPi [Main] or [Test]
+        required: true
+        default: 'Main'
+
+jobs:
+  build-and-release:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5.6.0
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        working-directory: packages/node-bin
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+
+      - name: Download node binary
+        run: python packages/node-bin/scripts/download-node.py
+
+      - name: Build wheel
+        working-directory: packages/node-bin
+        run: python -m build --wheel
+
+      - name: Fix wheels
+        working-directory: packages/node-bin
+        run: python scripts/fix-wheels.py dist/
+
+      - name: Validate dist
+        working-directory: packages/node-bin
+        run: twine check dist/*
+
+      - if: github.event.inputs.pypi-target == 'Main'
+        name: Publish to PyPi
+        working-directory: packages/node-bin
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: twine upload dist/*
+
+      - if: github.event.inputs.pypi-target == 'Test'
+        name: Publish to Test-PyPi
+        working-directory: packages/node-bin
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TEST_API_TOKEN }}
+        run: twine upload --repository testpypi dist/*

--- a/neo3/sctesting/node.py
+++ b/neo3/sctesting/node.py
@@ -15,7 +15,7 @@ from neo3.api.wrappers import ChainFacade
 from neo3.api.helpers.txbuilder import START_IGNORE_RUNTIMELOG, STOP_IGNORE_RUNTIMELOG
 from typing import Optional
 from dataclasses import dataclass
-
+from neo_go_node import get_binary_path
 
 log = logging.getLogger("neogo")
 log.addHandler(logging.StreamHandler(sys.stdout))
@@ -60,15 +60,10 @@ class NeoGoNode:
             )
 
         self.system = platform.system().lower()
-        self.prog = "neogo"
+        self.prog = str(get_binary_path())
         self.posix = True
         if self.system == "windows":
-            self.prog += ".exe"
             self.posix = False
-        if not self.data_dir.joinpath(self.prog).exists():
-            raise FileNotFoundError(
-                f"Internal required file '{self.prog}' not found. If you installed from source run this command once `python scripts/download-node.py`"
-            )
 
         self._thread: Optional[threading.Thread] = None
         self._process: Optional[subprocess.Popen[str]] = None
@@ -80,7 +75,7 @@ class NeoGoNode:
     def start(self):
         log.debug("starting")
 
-        cmd = f"{self.data_dir}/{self.prog} node --config-file {self.config_path} --relative-path {self.data_dir}"
+        cmd = f"{self.prog} node --config-file {self.config_path} --relative-path {self.data_dir}"
 
         self._process = subprocess.Popen(
             shlex.split(cmd, posix=self.posix),

--- a/packages/node-bin/LICENSE.md
+++ b/packages/node-bin/LICENSE.md
@@ -1,0 +1,19 @@
+Copyright (c) 2019-present COZ
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/node-bin/neo_go_node/__init__.py
+++ b/packages/node-bin/neo_go_node/__init__.py
@@ -6,5 +6,5 @@ import platform
 def get_binary_path() -> Path:
     suffix = ".exe" if platform.system() == "Windows" else ""
     path = Path(__file__).parent / "bin" / f"neogo{suffix}"
-    path.chmod(path.stat().st_mode | stat.S_IEXEC)  # no-op on Windows, fine
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
     return path

--- a/packages/node-bin/neo_go_node/__init__.py
+++ b/packages/node-bin/neo_go_node/__init__.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+import stat
+import platform
+
+
+def get_binary_path() -> Path:
+    suffix = ".exe" if platform.system() == "Windows" else ""
+    path = Path(__file__).parent / "bin" / f"neogo{suffix}"
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)  # no-op on Windows, fine
+    return path

--- a/packages/node-bin/pyproject.toml
+++ b/packages/node-bin/pyproject.toml
@@ -1,0 +1,39 @@
+[project]
+name = "neo-go-node"
+description = "Platform-specific neo-go binary"
+version = "0.119.0"
+requires-python = ">= 3.13.0,< 3.15"
+license = 'MIT'
+license-files = ["LICENSE.md"]
+keywords = ["NEO3", "blockchain", "node"]
+authors = [
+    { name = "Erik van den Brink", email = "erik@coz.io" },
+]
+maintainers = [
+    { name = "Erik van den Brink", email = "erik@coz.io" },
+]
+readme = {text = "Platform-specific neo-go binary distribution for neo-mamba. Not intended for direct use — install via `pip install neo-mamba[sctesting]`.", content-type = "text/markdown"}
+
+[project.optional-dependencies]
+dev = [
+   "build==1.0.3",
+   "requests",
+   "tomlkit==0.15.0",
+   "types-PyYAML",
+   "twine",
+   "wheel"
+]
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["neo_go_node*"]
+
+[tool.setuptools.package-data]
+neo_go_node = ["bin/*"]
+
+[tool.neogo]
+tag = "v0.119.0"

--- a/packages/node-bin/scripts/download-node.py
+++ b/packages/node-bin/scripts/download-node.py
@@ -26,7 +26,8 @@ def chmod_plus_x(path):
 
 
 def main():
-    with open("../pyproject.toml") as f:
+    project_file = pathlib.Path(__file__).parent.parent.joinpath("pyproject.toml")
+    with open(project_file) as f:
         doc = parse(f.read())
         target_tag = doc["tool"]["neogo"]["tag"]
 
@@ -66,7 +67,7 @@ def main():
                         end="",
                     )
                     data_dir = pathlib.Path(__file__).parent.parent.joinpath(
-                        "neo3/sctesting/data"
+                        "neo_go_node/bin"
                     )
                     binary_filename = f"{data_dir}/neogo"
                     if system == "windows":

--- a/packages/node-bin/scripts/fix-wheels.py
+++ b/packages/node-bin/scripts/fix-wheels.py
@@ -1,7 +1,6 @@
 """
 This script is a helper script to correctly rename wheels.
 
-While the boaconstructor package is all in Python, it relies on a platform specific executable (neo-go) in the background.
 The CI setup will fetch the platform specific neo-go executable and place it in the correct directory where it will be
 picked up when packaging. `python -m build` creates a universal wheel and that needs to be fixed to include the correct
 platform tag before uploading to PyPi. This cannot be done by simply renaming the file, it also does internal changes in
@@ -12,7 +11,7 @@ import sys
 import pathlib
 import sysconfig
 import platform
-from wheel.cli.tags import tags
+import subprocess
 
 
 def main(wheel_dir):
@@ -25,7 +24,12 @@ def main(wheel_dir):
             platform_tag = platform_tag.replace("universal2", "x86_64")
     for f in pathlib.Path(wheel_dir).glob("**/*"):
         if f.name.endswith("any.whl"):
-            tags(str(f.absolute()), None, None, platform_tag, None, True)
+            subprocess.run([
+                sys.executable, "-m", "wheel", "tags",
+                "--platform-tag", platform_tag,
+                "--remove",
+                str(f.absolute())
+            ], check=True)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,9 @@ docs = [
 ]
 
 sctesting = [
-   "requests",
-   "PyYAML",
+    "requests",
+    "PyYAML",
+    "neo-go-node==0.119.0"
 ]
 
 [project.urls]
@@ -99,9 +100,6 @@ source = ["neo3"]
 
 [tool.coverage.report]
 omit = ["neo3/core/cryptography/ecc*"]
-
-[tool.neogo]
-tag = "v0.118.0"
 
 [project.scripts]
 neo3-compile = "cli.compile:main"

--- a/tests/compiler/tests-e2e/native_contract_wrappers/ledger/test_wrapper_ledger.py
+++ b/tests/compiler/tests-e2e/native_contract_wrappers/ledger/test_wrapper_ledger.py
@@ -50,12 +50,9 @@ class TestLedgerWrapper(SmartContractTestCase):
         result, _ = await self.call("get_block_exists", [0], return_type=bool)
         self.assertTrue(result)
 
-    async def test_get_block_faults_for_future_index(self) -> None:
-        # BUG in neo-go node: getBlock should return None for a non-existent block index,
-        # but instead faults the VM with "no block with index <N>".
-        # This test should be updated to assertFalse(result) once the neo-go node is fixed.
-        with self.assertRaises(Exception):
-            await self.call("get_block_exists", [999_999_999], return_type=bool)
+    async def test_get_block_for_future_index(self) -> None:
+        result, _ = await self.call("get_block_exists", [999_999_999], return_type=bool)
+        self.assertFalse(result)
 
     async def test_get_block_index_field_matches(self) -> None:
         result, _ = await self.call("get_block_index_field", [0], return_type=int)


### PR DESCRIPTION
close #387 

The `neo-go` binary requirement for the `sctesting` optional dependency is now (manually) published as separate wheel via the `node-bin` package. This ensures installing `sctesting` installs all things necessary without any manual steps and at the same time keep mamba small if `sctesting` is not used. Also made the wheel fixing logic more resilient against `wheel` version changes.

Publishing a new `neo-go-node` is done as follows:
- in packages/node-bin/pyproject.toml
   - update the `tool.neogo` tag
   - update `version` to match the tag without the `v`
- run the `release-node-to-pypi.yml` github action 
