### PR TITLE
cli: rename program name and add `create` command

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -15,12 +15,15 @@ def cmd_version(_: argparse.Namespace) -> int:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        prog="neo3",
+        prog="mamba",
         description="NEO smart contract toolchain",
     )
     parser.set_defaults(func=None)
 
     subparsers = parser.add_subparsers(title="commands", metavar="<command>")
+
+    create_parser = subparsers.add_parser("create", help="Create a new dApp with a smart contract and tests")
+    create_parser.set_defaults(func=scaffold_init)
 
     version_parser = subparsers.add_parser("version", help="Print the SDK version")
     version_parser.set_defaults(func=cmd_version)

--- a/cli/cmd_contract_init.py
+++ b/cli/cmd_contract_init.py
@@ -63,7 +63,6 @@ class TestAbort(SmartContractTestCase):
 
 
 def scaffold_init(args: argparse.Namespace) -> int:
-    """neo3 contract init <name>"""
     name = args.name
     contract_path = Path(f"{name}.py")
     test_path = Path(f"test_{name}.py")

--- a/docs/source/smart-contracts.md
+++ b/docs/source/smart-contracts.md
@@ -272,7 +272,7 @@ def get_hello_world() -> str:
 ```
 
 !!! note
-    Compile the code with `neo3 contract compile hello_world.py`.
+    Compile the code with `mamba contract compile hello_world.py`.
 
 Let's unpack the example. The `@public` decorator tells the compiler that the function should be made callable from the 
 outside world. In the example `save_hello_world` and `get_hello_world` are the function names that will be exposed via a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,4 +102,4 @@ source = ["neo3"]
 omit = ["neo3/core/cryptography/ecc*"]
 
 [project.scripts]
-neo3 = "cli.__init__:main"
+mamba = "cli.__init__:main"


### PR DESCRIPTION
- Renamed the CLI command from `neo3` to `mamba` based on some  feedback from Tyler.
- Added a `create` command that currently mirrors the `contract init` command, but over time will add off-chain SDK generation as well (similar to CPM).